### PR TITLE
Use ABC for the forward model

### DIFF
--- a/examples/MOC_Model.py
+++ b/examples/MOC_Model.py
@@ -347,6 +347,7 @@ class MOCModel(ForwardModelBaseClass):
 
     def _advance(self,
                  step: int,
+                 time: float,
                  dt: float,
                  noise: Any,
                  forcingAmpl: float) -> float:

--- a/examples/MOC_Model.py
+++ b/examples/MOC_Model.py
@@ -537,7 +537,7 @@ class MOCModel(ForwardModelBaseClass):
             return (self.q_N_on - q_N) / (self.q_N_on - z)
         return (self.q_N_off_full - q_N) / (self.q_N_off_full - self.q_N_on)
 
-    def _get_noise(self):
+    def _make_noise(self):
         """Return a random noise."""
         return np.random.normal()
 

--- a/examples/MOC_Model.py
+++ b/examples/MOC_Model.py
@@ -1,6 +1,6 @@
+from typing import Any
 import netCDF4 as netcdf
 import numpy as np
-from typing import Any
 from pytams.fmodel import ForwardModelBaseClass
 from pytams.tams import TAMS
 

--- a/examples/doubleWell3D.py
+++ b/examples/doubleWell3D.py
@@ -43,10 +43,11 @@ class DoubleWellModel3D(ForwardModelBaseClass):
         return np.array([-1.0, 0.0, 0.0])
 
     def _advance(self,
-                step: int,
-                dt: float,
-                noise: Any,
-                forcingAmpl: float) -> float:
+                 step: int,
+                 time: float,
+                 dt: float,
+                 noise: Any,
+                 forcingAmpl: float) -> float:
         """Override the template."""
         self._state = (
                 self._state + dt * self.__RHS(self._state) + forcingAmpl * self.__dW(dt, noise[:3])

--- a/examples/doubleWell3D.py
+++ b/examples/doubleWell3D.py
@@ -1,7 +1,6 @@
 import time
-import sys
-import numpy as np
 from typing import Any
+import numpy as np
 from pytams.fmodel import ForwardModelBaseClass
 from pytams.tams import TAMS
 

--- a/examples/doubleWell3D.py
+++ b/examples/doubleWell3D.py
@@ -74,7 +74,7 @@ class DoubleWellModel3D(ForwardModelBaseClass):
         f2 = 1.0 - f1
         return f1 - f1 * np.exp(-8 * da) + f2 * np.exp(-8 * db)
 
-    def _get_noise(self):
+    def _make_noise(self):
         """Override the template."""
         return self._rng.standard_normal(10)
 

--- a/pytams/fmodel.py
+++ b/pytams/fmodel.py
@@ -79,7 +79,7 @@ class ForwardModelBaseClass(metaclass=ABCMeta):
         """
         # Get noise for the next model step
         if not self._prescribed_noise:
-            self._noise = self._get_noise()
+            self._noise = self._make_noise()
 
         try:
             actual_dt = self._advance(self._step, dt, self._noise, forcingAmpl)
@@ -127,7 +127,7 @@ class ForwardModelBaseClass(metaclass=ABCMeta):
         return self._noise
 
     @abstractmethod
-    def _get_noise(self) -> Any:
+    def _make_noise(self) -> Any:
         """Return the model's latest noise increment."""
         raise BaseClassCallError("Calling getNoise method !")
 

--- a/pytams/fmodel.py
+++ b/pytams/fmodel.py
@@ -2,6 +2,7 @@ from abc import ABCMeta
 from abc import abstractmethod
 from typing import Any
 from typing import Optional
+from typing import final
 
 
 class ForwardModelError(Exception):
@@ -31,6 +32,7 @@ class ForwardModelBaseClass(metaclass=ABCMeta):
     """
 
 
+    @final
     def __init__(self,
                  params: Optional[dict] = None,
                  ioprefix: Optional[str] = None):
@@ -52,19 +54,7 @@ class ForwardModelBaseClass(metaclass=ABCMeta):
         # Call the concrete class init method
         self._init_model(params, ioprefix)
 
-    @abstractmethod
-    def _init_model(self,
-                    params: Optional[dict] = None,
-                    ioprefix: Optional[str] = None) -> None:
-        """Concrete class specific initialization.
-
-        Args:
-            params: an optional dict containing parameters
-            ioprefix: an optional string defining run folder (TOCHECK)
-        """
-        pass
-
-
+    @final
     def advance(self,
                 dt: float,
                 forcingAmpl: float) -> float:
@@ -103,6 +93,34 @@ class ForwardModelBaseClass(metaclass=ABCMeta):
 
         return actual_dt
 
+    @final
+    def getNoise(self) -> Any:
+        """Return the model's latest noise increment."""
+        return self._noise
+
+    @final
+    def setNoise(self, a_noise : Any) -> None:
+        """Set the model's next noise increment."""
+        self._prescribed_noise = True
+        self._noise = a_noise
+
+    @final
+    def clear(self) -> None:
+        """Destroy internal data."""
+        self._clear_model()
+
+    @abstractmethod
+    def _init_model(self,
+                    params: Optional[dict] = None,
+                    ioprefix: Optional[str] = None) -> None:
+        """Concrete class specific initialization.
+
+        Args:
+            params: an optional dict containing parameters
+            ioprefix: an optional string defining run folder (TOCHECK)
+        """
+        pass
+
     @abstractmethod
     def _advance(self,
                  step: int,
@@ -114,6 +132,7 @@ class ForwardModelBaseClass(metaclass=ABCMeta):
 
         Args:
             step: the current step counter
+            time: the starting time of the advance call
             dt: the time step size over which to advance
             noise: the noise to be used in the model step
             forcingAmpl: stochastic multiplicator
@@ -122,35 +141,28 @@ class ForwardModelBaseClass(metaclass=ABCMeta):
         """
         raise BaseClassCallError("Calling base class _advance() method !")
 
-
+    @abstractmethod
     def getCurState(self) -> Any:
         """Return the current state of the model."""
-        raise BaseClassCallError("Calling getCurState() method !")
+        raise BaseClassCallError("Calling base class getCurState method !")
 
+    @abstractmethod
     def setCurState(self, state : Any) -> Any:
         """Set the current state of the model."""
-        raise BaseClassCallError("Calling setCurState method !")
+        raise BaseClassCallError("Calling base class setCurState method !")
 
+    @abstractmethod
     def score(self) -> Any:
         """Return the model's current state score."""
-        raise BaseClassCallError("Calling score method !")
-
-    def getNoise(self) -> Any:
-        """Return the model's latest noise increment."""
-        return self._noise
+        raise BaseClassCallError("Calling base class score method !")
 
     @abstractmethod
     def _make_noise(self) -> Any:
         """Return the model's latest noise increment."""
-        raise BaseClassCallError("Calling getNoise method !")
+        raise BaseClassCallError("Calling base class _make_noise method !")
 
-    def setNoise(self, a_noise : Any) -> None:
-        """Set the model's next noise increment."""
-        self._prescribed_noise = True
-        self._noise = a_noise
-
-    def clear(self) -> None:
-        """Destroy internal data."""
+    def _clear_model(self) -> Any:
+        """Clear the concrete forward model internals."""
         pass
 
     @classmethod

--- a/pytams/fmodel.py
+++ b/pytams/fmodel.py
@@ -1,5 +1,6 @@
 from typing import Any
 from typing import Optional
+from abc import ABCMeta, abstractmethod
 
 
 class ForwardModelError(Exception):
@@ -8,28 +9,66 @@ class ForwardModelError(Exception):
     pass
 
 
-class TemplateCallError(ForwardModelError):
-    """Template ForwardModel method called !"""
+class BaseClassCallError(ForwardModelError):
+    """BaseClass ForwardModel method called !"""
 
     pass
 
 
-class ForwardModel:
-    """A template class for the stochastic forward model.
+class AdvanceError(ForwardModelError):
+    """Concrete ForwardModel _advance error !"""
+
+    pass
+
+
+class ForwardModelBaseClass(metaclass=ABCMeta):
+    """A base class for the stochastic forward model.
 
     Implement the core methods required of the forward
     model within the TAMS context. Exception are thrown
-    if those functions are not overritten in actual model.
+    if required functions are not overritten in actual model.
     """
+
 
     def __init__(self,
                  params: Optional[dict] = None,
                  ioprefix: Optional[str] = None):
-        """Might need something here."""
+        """Base class __init__ method.
+
+        The base forwardmodel class handles some components
+        needed by TAMS regardless of the model.
+
+        Args:
+            params: an optional dict containing parameters
+            ioprefix: an optional string defining run folder (TOCHECK)
+        """
+        self._init_model(params, ioprefix)
+        self._prescribed_noise : bool = False
+        self._noise : Any = None
+        self._step : int = 0
+
+    @abstractmethod
+    def _init_model(self,
+                    params: Optional[dict] = None,
+                    ioprefix: Optional[str] = None) -> None:
+        """Concrete class specific initialization.
+
+        Args:
+            params: an optional dict containing parameters
+            ioprefix: an optional string defining run folder (TOCHECK)
+        """
         pass
 
-    def advance(self, dt: float, forcingAmpl: float) -> float:
-        """Advance function of the model.
+
+    def advance(self,
+                dt: float,
+                forcingAmpl: float) -> float:
+        """Base class advance function of the model.
+
+        The base class advance function update the internal
+        step counter and manage the generation (or reuse)
+        of the stochastic noise.
+        It also handles exceptions.
 
         Args:
             dt: the time step size over which to advance
@@ -37,27 +76,63 @@ class ForwardModel:
         Return:
             Some model will not do exactly dt (e.g. sub-stepping) return the actual dt
         """
-        raise TemplateCallError("Calling advance() method !")
+        # Get noise for the next model step
+        if not self._prescribed_noise:
+            self._noise = self._get_noise()
+
+        try:
+            actual_dt = self._advance(self._step, dt, self._noise, forcingAmpl)
+        except:
+            raise AdvanceError("Damn it !")
+
+        self._prescribed_noise = False
+
+        return actual_dt
+
+    @abstractmethod
+    def _advance(self,
+                 step: int,
+                 dt: float,
+                 noise: Any,
+                 forcingAmpl: float) -> float:
+        """Concrete class advance function.
+
+        Args:
+            step: the current step counter
+            dt: the time step size over which to advance
+            noise: the noise to be used in the model step
+            forcingAmpl: stochastic multiplicator
+        Return:
+            Some model will not do exactly dt (e.g. sub-stepping) return the actual dt
+        """
+        raise BaseClassCallError("Calling base class _advance() method !")
+
 
     def getCurState(self) -> Any:
         """Return the current state of the model."""
-        raise TemplateCallError("Calling getCurState() method !")
+        raise BaseClassCallError("Calling getCurState() method !")
 
     def setCurState(self, state : Any) -> Any:
         """Set the current state of the model."""
-        raise TemplateCallError("Calling setCurState method !")
+        raise BaseClassCallError("Calling setCurState method !")
 
     def score(self) -> Any:
         """Return the model's current state score."""
-        raise TemplateCallError("Calling score method !")
+        raise BaseClassCallError("Calling score method !")
 
     def getNoise(self) -> Any:
         """Return the model's latest noise increment."""
-        raise TemplateCallError("Calling getNoise method !")
+        return self._noise
+
+    @abstractmethod
+    def _get_noise(self) -> Any:
+        """Return the model's latest noise increment."""
+        raise BaseClassCallError("Calling getNoise method !")
 
     def setNoise(self, a_noise : Any) -> None:
         """Set the model's next noise increment."""
-        raise TemplateCallError("Calling setNoise method !")
+        self._prescribed_noise = True
+        self._noise = a_noise
 
     def clear(self) -> None:
         """Destroy internal data."""
@@ -66,4 +141,4 @@ class ForwardModel:
     @classmethod
     def name(cls) -> str:
         """Return a the model name."""
-        return "TemplateForwardModel"
+        return "BaseClassForwardModel"

--- a/pytams/fmodel.py
+++ b/pytams/fmodel.py
@@ -1,6 +1,7 @@
+from abc import ABCMeta
+from abc import abstractmethod
 from typing import Any
 from typing import Optional
-from abc import ABCMeta, abstractmethod
 
 
 class ForwardModelError(Exception):
@@ -82,9 +83,10 @@ class ForwardModelBaseClass(metaclass=ABCMeta):
 
         try:
             actual_dt = self._advance(self._step, dt, self._noise, forcingAmpl)
-        except:
+        except AdvanceError:
             raise AdvanceError("Damn it !")
 
+        # After a step, always reset flag to false
         self._prescribed_noise = False
 
         return actual_dt

--- a/tests/models.py
+++ b/tests/models.py
@@ -39,7 +39,7 @@ class SimpleFModel(ForwardModelBaseClass):
         """Override the template."""
         return min(self._state * 10.0, 1.0)
 
-    def _get_noise(self) -> float:
+    def _make_noise(self) -> float:
         """Override the template."""
         return 0.0
 
@@ -115,7 +115,7 @@ class DoubleWellModel(ForwardModelBaseClass):
         f2 = 1.0 - f1
         return f1 - f1 * np.exp(-8 * da) + f2 * np.exp(-8 * db)
 
-    def _get_noise(self):
+    def _make_noise(self):
         """Override the template."""
         return np.random.randn(2)
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,5 +1,6 @@
 import time
-from typing import Optional, Any
+from typing import Any
+from typing import Optional
 import numpy as np
 from pytams.fmodel import ForwardModelBaseClass
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -20,6 +20,7 @@ class SimpleFModel(ForwardModelBaseClass):
 
     def _advance(self,
                  step: int,
+                 time: float,
                  dt: float,
                  noise: Any,
                  forcingAmpl: float) -> float:
@@ -86,6 +87,7 @@ class DoubleWellModel(ForwardModelBaseClass):
 
     def _advance(self,
                  step: int,
+                 time: float,
                  dt: float,
                  noise: Any,
                  forcingAmpl: float) -> float:

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,23 +1,27 @@
 import time
-from typing import Optional
+from typing import Optional, Any
 import numpy as np
-from pytams.fmodel import ForwardModel
+from pytams.fmodel import ForwardModelBaseClass
 
 
-class SimpleFModel(ForwardModel):
+class SimpleFModel(ForwardModelBaseClass):
     """Simple forward model.
 
     The state is the time and score
     10 times the state, ceiled to 1.0
     """
 
-    def __init__(self,
-                 params: Optional[dict] = None,
-                 ioprefix: Optional[str] = None):
-        """Override the template."""
+    def _init_model(self,
+                    params: Optional[dict] = None,
+                    ioprefix: Optional[str] = None):
+        """Initialize model state."""
         self._state : float = 0.0
 
-    def advance(self, dt: float, forcingAmpl: float) -> float:
+    def _advance(self,
+                 step: int,
+                 dt: float,
+                 noise: Any,
+                 forcingAmpl: float) -> float:
         """Override the template."""
         self._state = self._state + dt
         return dt
@@ -34,13 +38,9 @@ class SimpleFModel(ForwardModel):
         """Override the template."""
         return min(self._state * 10.0, 1.0)
 
-    def getNoise(self) -> float:
+    def _get_noise(self) -> float:
         """Override the template."""
         return 0.0
-
-    def setNoise(self, a_noise) -> None:
-        """Override the template."""
-        pass
 
     @classmethod
     def name(cls):
@@ -48,7 +48,7 @@ class SimpleFModel(ForwardModel):
         return "SimpleFModel"
 
 
-class DoubleWellModel(ForwardModel):
+class DoubleWellModel(ForwardModelBaseClass):
     """2D double well forward model.
 
     V(x,y) = x^4/4 - x^2/2 + y^2
@@ -62,13 +62,12 @@ class DoubleWellModel(ForwardModel):
     With the 2 wells at [-1.0, 0.0] and [1.0, 0.0]
     """
 
-    def __init__(self,
-                 params: Optional[dict] = None,
-                 ioprefix: Optional[str] = None):
+    def _init_model(self,
+                    params: Optional[dict] = None,
+                    ioprefix: Optional[str] = None):
         """Override the template."""
         self._state = self.initCondition()
-        self._slow_factor = params.get("model",{}).get("slow_factor",0.00001)
-        self._prescribed_noise = False
+        self._slow_factor = params.get("model",{}).get("slow_factor",0.00000001)
 
     def __RHS(self, state):
         """Double well RHS function."""
@@ -76,22 +75,23 @@ class DoubleWellModel(ForwardModel):
         time.sleep(sleepTime)
         return np.array([state[0] - state[0] ** 3, -2 * state[1]])
 
-    def __dW(self, dt):
+    def __dW(self, dt, noise):
         """Stochastic forcing."""
-        if not self._prescribed_noise:
-            self._rand = np.random.randn(2)
-        return np.sqrt(dt) * self._rand
+        return np.sqrt(dt) * noise
 
     def initCondition(self):
         """Return the initial conditions."""
         return np.array([-1.0, 0.0])
 
-    def advance(self, dt: float, forcingAmpl: float) -> float:
+    def _advance(self,
+                 step: int,
+                 dt: float,
+                 noise: Any,
+                 forcingAmpl: float) -> float:
         """Override the template."""
         self._state = (
-            self._state + dt * self.__RHS(self._state) + forcingAmpl * self.__dW(dt)
+            self._state + dt * self.__RHS(self._state) + forcingAmpl * self.__dW(dt, noise)
         )
-        self._prescribed_noise = False
         return dt
 
     def getCurState(self):
@@ -114,14 +114,9 @@ class DoubleWellModel(ForwardModel):
         f2 = 1.0 - f1
         return f1 - f1 * np.exp(-8 * da) + f2 * np.exp(-8 * db)
 
-    def getNoise(self):
+    def _get_noise(self):
         """Override the template."""
-        return self._rand
-
-    def setNoise(self, a_noise) -> None:
-        """Override the template."""
-        self._rand = a_noise
-        self._prescribed_noise = True
+        return np.random.randn(2)
 
     @classmethod
     def name(cls):

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -50,7 +50,7 @@ def test_generateAndLoadTDB():
                    "database": {"DB_save": True, "DB_prefix": "dwTest"},
                    "dask": {"nworker_init": 2, "nworker_iter": 2},
                    "trajectory": {"end_time": 10.0, "step_size": 0.01,
-                                  "targetscore": 0.7, "stoichforcing" : 0.8}}, f)
+                                  "targetscore": 0.6, "stoichforcing" : 0.8}}, f)
     tams = TAMS(fmodel_t=fmodel, a_args=[])
     tams.compute_probability()
 

--- a/tests/test_tams.py
+++ b/tests/test_tams.py
@@ -3,7 +3,6 @@ import os
 import shutil
 import pytest
 import toml
-from pytams.fmodel import ForwardModel
 from pytams.tams import TAMS
 from tests.models import DoubleWellModel
 from tests.models import SimpleFModel
@@ -11,7 +10,7 @@ from tests.models import SimpleFModel
 
 def test_initTAMS():
     """Test TAMS initialization."""
-    fmodel = ForwardModel
+    fmodel = SimpleFModel
     with open("input.toml", 'w') as f:
         toml.dump({"tams": {"ntrajectories": 500}}, f)
     tams = TAMS(fmodel_t=fmodel, a_args=[])

--- a/tests/test_tams.py
+++ b/tests/test_tams.py
@@ -93,7 +93,7 @@ def test_doublewellModel2WorkersTAMS():
                    "database": {"DB_save": True, "DB_prefix": "dwTest"},
                    "dask": {"nworker_init": 2, "nworker_iter": 2},
                    "trajectory": {"end_time": 10.0, "step_size": 0.01,
-                                  "targetscore": 0.7, "stoichforcing" : 0.8}}, f)
+                                  "targetscore": 0.6, "stoichforcing" : 0.8}}, f)
     tams = TAMS(fmodel_t=fmodel, a_args=[])
     transition_proba = tams.compute_probability()
     assert transition_proba >= 0.2
@@ -108,7 +108,7 @@ def test_doublewellModel2WorkersRestoreTAMS():
                                 "DB_restart": "dwTest.tdb"},
                    "dask": {"nworker_init": 2, "nworker_iter": 2},
                    "trajectory": {"end_time": 10.0, "step_size": 0.01,
-                                  "targetscore": 0.7, "stoichforcing" : 0.8}}, f)
+                                  "targetscore": 0.6, "stoichforcing" : 0.8}}, f)
     tams = TAMS(fmodel_t=fmodel, a_args=[])
     transition_proba = tams.compute_probability()
     assert transition_proba >= 0.2

--- a/tests/test_trajectory.py
+++ b/tests/test_trajectory.py
@@ -26,7 +26,7 @@ def test_initBaseClassError():
     fmodel = ForwardModelBaseClass
     parameters = {}
     with pytest.raises(Exception):
-        t_test = Trajectory(fmodel, parameters, "ttest")
+        _ = Trajectory(fmodel, parameters, "ttest")
 
 
 def test_initBlankTraj():

--- a/tests/test_trajectory.py
+++ b/tests/test_trajectory.py
@@ -2,7 +2,7 @@
 import os
 from math import isclose
 import pytest
-from pytams.fmodel import ForwardModel
+from pytams.fmodel import ForwardModelBaseClass
 from pytams.trajectory import Snapshot
 from pytams.trajectory import Trajectory
 from tests.models import SimpleFModel
@@ -21,9 +21,17 @@ def test_initSnapshotNoState():
     assert not snap.hasState()
 
 
+def test_initBaseClassError():
+    """Test using base class fmodel during trajectory creation."""
+    fmodel = ForwardModelBaseClass
+    parameters = {}
+    with pytest.raises(Exception):
+        t_test = Trajectory(fmodel, parameters, "ttest")
+
+
 def test_initBlankTraj():
     """Test blank trajectory creation."""
-    fmodel = ForwardModel
+    fmodel = SimpleFModel
     parameters = {}
     t_test = Trajectory(fmodel, parameters, "ttest")
     assert t_test.id() == "ttest"
@@ -33,7 +41,7 @@ def test_initBlankTraj():
 
 def test_initParametrizedTraj():
     """Test parametrized trajectory creation."""
-    fmodel = ForwardModel
+    fmodel = SimpleFModel
     parameters = {"trajectory" : {"end_time": 2.0,
                                   "step_size": 0.01,
                                   "targetscore": 0.25}}
@@ -43,22 +51,11 @@ def test_initParametrizedTraj():
 
 def test_restartEmptyTraj():
     """Test (empty) trajectory restart."""
-    fmodel = ForwardModel
+    fmodel = SimpleFModel
     parameters = {}
     t_test = Trajectory(fmodel, parameters, "ttest")
     rst_test = Trajectory.restartFromTraj(t_test, "ttest", 0.1)
     assert rst_test.ctime() == 0.0
-
-
-def test_templateModelExceptions():
-    """Test trajectory exception with template model."""
-    fmodel = ForwardModel
-    parameters = {"trajectory" : {"end_time": 0.04,
-                                  "step_size": 0.001,
-                                  "targetscore": 0.25}}
-    t_test = Trajectory(fmodel, parameters, "ttest")
-    with pytest.raises(Exception):
-        t_test.advance()
 
 
 def test_simpleModelTraj():


### PR DESCRIPTION
The forward models are now inheriting from a `ForwardModelBaseClass` which implement some common tooling
needed by any forward model within TAMS:
 - handling of the source of noise
 - a step counter

Other common features can be added in the future if needed.

Only a few `@abstractmethod` are needed by the concrete forward models, all of which are private with the BaseClass handling the public methods:
 - `_init_model()`
 - `_advance()`
 - `_make_noise()`

- [x] Add a time counter in baseclass
- [x] Finish decorating the abstractmethod
