### PR TITLE
Detach database

### DIFF
--- a/examples/input_MOC.toml
+++ b/examples/input_MOC.toml
@@ -1,23 +1,23 @@
 [tams]
 ntrajectories = 100
 nsplititer = 1000
-loglevel = "WARNING"
+loglevel = "INFO"
 
 
 [trajectory]
 end_time = 3153600000
 step_size = 86400
 targetscore = 1.00
+sparse_freq = 10
 stoichforcing = 0
 
 [model]
 test_param = "toto"
 
-[dask]
-nworker_init=6
+[runner]
+type = "asyncio"
+nworker_init=2
 nworker_iter=2
 
 [database]
-DB_save = false
-DB_prefix = "DW_3DTest"
-#DB_restart = "DW_3DTest.tdb"
+path = "MOCTest.tdb"

--- a/pytams/database.py
+++ b/pytams/database.py
@@ -1,8 +1,10 @@
 """A database class for TAMS."""
+from __future__ import annotations
 import copy
 import logging
 import os
 import shutil
+import sys
 import xml.etree.ElementTree as ET
 from datetime import datetime
 from importlib.metadata import version
@@ -10,6 +12,8 @@ from pathlib import Path
 from typing import Any
 from typing import Optional
 from typing import Union
+import cloudpickle
+import dill
 import matplotlib.pyplot as plt
 import numpy as np
 import toml
@@ -32,7 +36,7 @@ class Database:
 
     The database class for TAMS is a container for
     all the trajectory and splitting data. When the
-    user requires to store the database, a local folder is
+    user provides a path to store the database, a local folder is
     created holding a number of readable files, any output
     from the model and an SQL file used to lock/release
     trajectories as the TAMS algorithm proceeds.
@@ -45,7 +49,8 @@ class Database:
     Attributes:
         _fmodel_t: the forward model type
         _save: boolean to trigger saving the database to disk
-        _load: a path to an existing database to restore
+        _path: a path to an existing database to restore or a new path
+        _restart: a bool to override an existing database
         _parameters: the dictionary of parameters
         _trajs_db: the list of trajectories
         _ksplit: the current splitting iteration
@@ -61,13 +66,12 @@ class Database:
                  nsplititer: Optional[int] = None) -> None:
         """Initialize a TAMS database.
 
-        Initialize in-memory TAMS database, loading data
-        from an existing database if provided.
+        Initialize TAMS database object, bare in-memory or on-disk.
 
-        To prevent overriding an existing database by mistake,
-        if a database folder with the same name already exists,
-        if will be copied to a new folder with a random name unless
-        that same folder is also specified as a restart database.
+        On-disk database trigger if a path is provided in the
+        parameters dictonary. The user can chose to not append/override
+        the existing database in which case the existing path
+        will be copied to a new random name.
 
         Args:
             fmodel_t: the forward model type
@@ -79,11 +83,25 @@ class Database:
 
         # Metadata
         self._save = False
-        self._load : Union[str,None] = None
         self._parameters = params
+        self._name = "TAMS_" + fmodel_t.name()
+        self._path = params.get("database", {}).get("path", None)
+        if self._path:
+            self._save = True
+            self._restart = params.get("database", {}).get("restart", False)
+            self._format = params.get("database", {}).get("format", "XML")
+            if self._format not in ["XML"]:
+                err_msg = f"Unsupported TAMS database format: {self._format} !"
+                _logger.error(err_msg)
+                raise DatabaseError(err_msg)
+            self._name = f"{self._path}"
+            self._abs_path : os.PathLike = Path.cwd() / self._name
+            self._creation_date = datetime.now()
+            self._version = version(__package__)
 
         # Trajectory Pool
         self._trajs_db : list[Trajectory] = []
+        self._pool_db = None
 
         # Splitting data
         self._ksplit = 0
@@ -91,27 +109,9 @@ class Database:
         self._weights : list[float] = [1.0]
         self._ongoing = None
 
-        self._save = params.get("database", {}).get("DB_save", False)
-        self._prefix = params.get("database", {}).get("DB_prefix", "TAMS")
-        self._load = params.get("database", {}).get("DB_restart", None)
-        self._format = params.get("database", {}).get("DB_format", "XML")
-        self._name = f"{self._prefix}.tdb"
-
-        if self._load:
-            self._name = self._load
-            self._restoreTrajDB()
-        else:
-            if not ntraj:
-                err_msg = "Initializing TAMS database from scratch require ntraj !"
-                _logger.error(err_msg)
-                raise DatabaseError(err_msg)
-            if not nsplititer:
-                err_msg = "Initializing TAMS database from scratch require nsplititer !"
-                _logger.error(err_msg)
-                raise DatabaseError(err_msg)
-            self._ntraj = ntraj
-            self._nsplititer = nsplititer
-            self._setUpTree()
+        # Initialize only metadata at this point
+        # so that the object remains lightweight
+        self._init_metadata(ntraj, nsplititer)
 
     def nTraj(self) -> int:
         """Return the number of trajectory used for TAMS.
@@ -135,40 +135,137 @@ class Database:
         """
         return self._nsplititer
 
-    def _setUpTree(self) -> None:
+    def path(self) -> str:
+        """Return the path to the database."""
+        return self._path
+
+    @classmethod
+    def load(cls,
+             a_path: os.PathLike) -> Database:
+        """Instanciate a TAMS database from disk.
+
+        Args:
+            a_path: the path to the database
+
+        Return:
+            a TAMS database object
+        """
+        if not a_path.exists():
+            err_msg = f"Database {a_path} does not exist !"
+            _logger.error(err_msg)
+            raise DatabaseError(err_msg)
+
+        # Load necessary elements to call the constructor
+        # Ensure that the database is not restarted at this step
+        db_params = toml.load(a_path / "input_params.toml")
+        db_params["database"].update({"restart": False})
+
+        # If the a_path differs from the one stored in the
+        # database (the DB has been moved), update the path
+        if str(a_path) != db_params["database"]["path"]:
+            warn_msg = f"Database {db_params['database']['path']} has been moved to {a_path} !"
+            _logger.warning(warn_msg)
+            db_params["database"]["path"] = str(a_path)
+        model_file = Path(a_path / "fmodel.pkl")
+        with model_file.open("rb") as f:
+            model = dill.load(f)
+
+        return cls(model, db_params)
+
+    def _init_metadata(self,
+                       ntraj: Optional[int] = None,
+                       nsplititer: Optional[int] = None) -> None:
+        """Initialize the database.
+
+        Initialize database internal metadata (only) and setup
+        the database on disk if needed.
+
+        Args:
+            ntraj: [OPT] number of traj to hold
+            nsplititer: [OPT] number of splitting iteration to hold
+        """
+        # Initialize or load disk-based database metadata
+        if self._save:
+            # Check for an existing database:
+            db_exists = self._abs_path.exists()
+
+            # Regardless of a pre-existing path we initialize from scratch
+            if (not db_exists or self._restart):
+                if not ntraj:
+                    err_msg = "Initializing TAMS database from scratch require ntraj !"
+                    _logger.error(err_msg)
+                    raise DatabaseError(err_msg)
+                if not nsplititer:
+                    err_msg = "Initializing TAMS database from scratch require nsplititer !"
+                    _logger.error(err_msg)
+                    raise DatabaseError(err_msg)
+                self._ntraj = ntraj
+                self._nsplititer = nsplititer
+                self._setup_tree()
+
+            # Load the database
+            else:
+                self._load_metadata()
+                # Parameters stored in the DB override
+                # newly provided parameters.
+                with Path(self._abs_path / "input_params.toml").open('r') as f:
+                    readInParams = toml.load(f)
+                self._parameters.update(readInParams)
+
+        # Initialize in-memory database metadata
+        else:
+            if not ntraj:
+                err_msg = "Initializing TAMS database from scratch require ntraj !"
+                _logger.error(err_msg)
+                raise DatabaseError(err_msg)
+            if not nsplititer:
+                err_msg = "Initializing TAMS database from scratch require nsplititer !"
+                _logger.error(err_msg)
+                raise DatabaseError(err_msg)
+            self._ntraj = ntraj
+            self._nsplititer = nsplititer
+
+
+    def _setup_tree(self) -> None:
         """Initialize the trajectory database tree."""
         if self._save:
-            if os.path.exists(self._name) and self._name != self._load:
+            if self._abs_path.exists():
                 rng = np.random.default_rng(12345)
                 copy_exists = True
                 while copy_exists:
                     random_int = rng.integers(0, 999999)
-                    name_rnd = f"{self._name}_{random_int:06d}"
-                    copy_exists = os.path.exists(name_rnd)
-                warn_msg = f"Database {self._name} already present. It will be copied to {name_rnd}"
+                    path_rnd = Path.cwd() / f"{self._name}_{random_int:06d}"
+                    copy_exists = path_rnd.exists()
+                warn_msg = f"Database {self._name} already present. It will be copied to {path_rnd.name}"
                 _logger.warning(warn_msg)
-                shutil.move(self._name, name_rnd)
+                shutil.move(self._name, path_rnd.absolute())
 
             os.mkdir(self._name)
 
             # Save the runtime options
-            with open(f"{self._name}/input_params.toml", 'w') as f:
+            with Path(self._abs_path / "input_params.toml").open('w') as f:
                 toml.dump(self._parameters, f)
 
             # Header file with metadata and pool DB
-            self._writeMetadata()
+            self._write_metadata()
+
+            # Serialize the model
+            model_file = Path(self._abs_path / "fmodel.pkl")
+            cloudpickle.register_pickle_by_value(sys.modules[self._fmodel_t.__module__])
+            with model_file.open("wb") as f:
+                cloudpickle.dump(self._fmodel_t, f)
 
             # Empty trajectories subfolder
-            os.mkdir(f"{self._name}/trajectories")
+            Path(self._abs_path / "trajectories").mkdir(parents=True)
 
-    def _writeMetadata(self) -> None:
+    def _write_metadata(self) -> None:
         """Write the database Metadata to disk."""
         if self._format == "XML":
-            headerFile = self.headerFile()
+            headerFile = self.header_file()
             root = ET.Element("header")
             mdata = ET.SubElement(root, "metadata")
             mdata.append(new_element("pyTAMS_version", version(__package__)))
-            mdata.append(new_element("date", datetime.now()))
+            mdata.append(new_element("date", self._creation_date))
             mdata.append(new_element("model_t", self._fmodel_t.name()))
             mdata.append(new_element("ntraj", self._ntraj))
             mdata.append(new_element("nsplititer", self._nsplititer))
@@ -177,37 +274,57 @@ class Database:
             tree.write(headerFile)
 
             # Initialialize splitting data file
-            self.saveSplittingData()
+            self.save_splitting_data()
 
             # Initialize the SQL pool file
-            self._pool_db = SQLFile(self.poolFile())
+            self._pool_db = SQLFile(self.pool_file())
         else:
             err_msg = f"Unsupported TAMS database format: {self._format} !"
             _logger.error(err_msg)
             raise DatabaseError(err_msg)
 
-    def _readHeader(self) -> tuple[str, datetime, str]:
-        """Read the database Metadata to header."""
-        if self._load:
+    def _load_metadata(self) -> None:
+        """Read the database Metadata from the header."""
+        if self._save:
             if self._format == "XML":
-                tree = ET.parse(self.headerFile())
+                tree = ET.parse(self.header_file())
                 root = tree.getroot()
                 mdata = root.find("metadata")
                 datafromxml = xml_to_dict(mdata)
-                pyTAMS_version = datafromxml["pyTAMS_version"]
-                db_date = datafromxml["date"]
+                self._ntraj = datafromxml["ntraj"]
+                self._nsplititer = datafromxml["nsplititer"]
+                self._version = datafromxml["pyTAMS_version"]
+                if self._version != version(__package__):
+                    warn_msg = f"Database pyTAMS version {self._version} is different from {version(__package__)}"
+                    _logger.warning(warn_msg)
+                self._creation_date = datafromxml["date"]
                 db_model = datafromxml["model_t"]
+                if db_model != self._fmodel_t.name():
+                    err_msg = f"Database model {db_model} is different from call {self._fmodel_t.name()}"
+                    _logger.error(err_msg)
+                    raise DatabaseError(err_msg)
 
-                return pyTAMS_version, db_date, db_model
+                # Initialize the SQL pool file
+                self._pool_db = SQLFile(self.pool_file())
             else:
                 err_msg = f"Unsupported TAMS database format: {self._format} !"
                 _logger.error(err_msg)
                 raise DatabaseError(err_msg)
-        else:
-            return "Error", datetime.min, "Error"
 
-    def saveSplittingData(self,
-                          ongoing_trajs: Optional[list[int]] = None) -> None:
+
+    def save_trajectory(self, traj: Trajectory) -> None:
+        """Save a trajectory to disk in the database.
+
+        Args:
+            traj: the trajectory to save
+        """
+        if not self._save:
+            return
+
+        traj.store()
+
+    def save_splitting_data(self,
+                            ongoing_trajs: Optional[list[int]] = None) -> None:
         """Write splitting data to the database.
 
         Args:
@@ -234,7 +351,7 @@ class Database:
             _logger.error(err_msg)
             raise DatabaseError(err_msg)
 
-    def _readSplittingData(self) -> None:
+    def _read_splitting_data(self) -> None:
         """Read splitting data."""
         # Read data file
         if self._format == "XML":
@@ -253,46 +370,18 @@ class Database:
             _logger.error(err_msg)
             raise DatabaseError(err_msg)
 
-    def _restoreTrajDB(self) -> None:
-        """Initialize TAMS from a stored trajectory database."""
-        assert(self._load is not None)
-        if os.path.exists(self._load):
-            inf_msg = f"Loading TAMS database: {self._load}"
-            _logger.info(inf_msg)
+    def load_data(self) -> None:
+        """Load data stored into the database."""
+        if not self._save:
+            return
 
-            # Check the database parameters against current run
-            self._check_database_consistency()
-
-            # Load splitting data
-            self._readSplittingData()
-
-            # Load trajectories stored in the database when available.
-            nTrajRestored = self.loadTrajectoryDB(self.poolFile())
-
-            inf_msg = f"{nTrajRestored} trajectories loaded"
-            _logger.info(inf_msg)
-        else:
-            err_msg = f"Could not find the {self._load} TAMS database !"
-            _logger.error(err_msg)
-            raise DatabaseError(err_msg)
-
-    def loadTrajectoryDB(self, dbFile: str) -> int:
-        """Load trajectories stored into the database.
-
-        Args:
-            dbFile: the database file
-
-        Return:
-            number of trajectories loaded
-        """
-        db_handle = SQLFile(dbFile)
         # Counter for number of trajectory loaded
         nTrajRestored = 0
 
-        ntraj_in_db = db_handle.get_trajectory_count()
+        ntraj_in_db = self._pool_db.get_trajectory_count()
         for n in range(ntraj_in_db):
-            trajChkFile = db_handle.fetch_trajectory(n)
-            if os.path.exists(trajChkFile):
+            trajChkFile = Path(self._abs_path) / self._pool_db.fetch_trajectory(n)
+            if trajChkFile.exists():
                 nTrajRestored += 1
                 self._trajs_db.append(
                     Trajectory.restoreFromChk(
@@ -301,45 +390,25 @@ class Database:
                         parameters=self._parameters
                     )
                 )
+                #self._trajs_db[-1].setCheckFile(trajChkFile.relative_to(self._abs_path))
+                self._trajs_db[-1].setCheckFile(trajChkFile)
             else:
                 T = Trajectory(
                     fmodel_t=self._fmodel_t,
-                    parameters=self.parameters,
+                    parameters=self._parameters,
                     trajId=n,
                 )
+                #T.setCheckFile(trajChkFile.relative_to(self._abs_path))
                 T.setCheckFile(trajChkFile)
                 self._trajs_db.append(T)
 
-        return nTrajRestored
+        inf_msg = f"{nTrajRestored} trajectories loaded"
+        _logger.info(inf_msg)
 
+        # Load splitting data
+        self._read_splitting_data()
 
-    def _check_database_consistency(self) -> None:
-        """Check the restart database consistency.
-
-        Perform some basic checks on the consistency between the
-        input file and the database being loaded.
-
-        Return:
-            DatabaseError if the consistency check fails
-        """
-        # Open and load header
-        tree = ET.parse(self.headerFile())
-        root = tree.getroot()
-        headerfromxml = xml_to_dict(root.find("metadata"))
-        if self._fmodel_t.name() != headerfromxml["model_t"]:
-            err_msg = f"Trying to restore a TAMS with {self._fmodel_t.name()}"\
-                      f"model from database with {headerfromxml['model_t']} model !"
-            _logger.error(err_msg)
-            raise DatabaseError(err_msg)
-
-        self._ntraj = headerfromxml["ntraj"]
-        self._nsplititer = headerfromxml["nsplititer"]
-
-        # Parameters stored in the DB override
-        # newly provided parameters.
-        with open(f"{self._load}/input_params.toml", 'r') as f:
-            readInParams = toml.load(f)
-        self._parameters.update(readInParams)
+        self.info()
 
     def name(self) -> str:
         """Accessor to DB name.
@@ -357,19 +426,24 @@ class Database:
         """
         return self._save
 
-    def appendTraj(self, a_traj: Trajectory) -> None:
+    def append_traj(self, a_traj: Trajectory) -> None:
         """Append a Trajectory to the internal list.
 
         Args:
             a_traj: the trajectory
         """
+        # Also adds it to the SQL pool file.
+        # and set the checkfile
+        if self._save:
+            checkfile_str = f"./trajectories/{a_traj.idstr()}.xml"
+            checkfile = Path(self._abs_path) / checkfile_str
+            a_traj.setCheckFile(checkfile)
+            self._pool_db.add_trajectory(checkfile_str)
+
         self._trajs_db.append(a_traj)
 
-        # Also adds it to the SQL pool file.
-        if self._save:
-            self._pool_db.add_trajectory(a_traj.checkFile())
 
-    def trajList(self) -> list[Trajectory]:
+    def traj_list(self) -> list[Trajectory]:
         """Access to the trajectory list.
 
         Return:
@@ -377,7 +451,7 @@ class Database:
         """
         return self._trajs_db
 
-    def getTraj(self, idx: int) -> Trajectory:
+    def get_traj(self, idx: int) -> Trajectory:
         """Access to a given trajectory.
 
         Args:
@@ -396,7 +470,7 @@ class Database:
             raise ValueError(err_msg)
         return self._trajs_db[idx]
 
-    def overwriteTraj(self,
+    def overwrite_traj(self,
                       idx: int,
                       traj: Trajectory) -> None:
         """Deep copy a trajectory into internal list.
@@ -415,7 +489,7 @@ class Database:
             raise ValueError(err_msg)
         self._trajs_db[idx] = copy.deepcopy(traj)
 
-    def headerFile(self) -> str:
+    def header_file(self) -> str:
         """Helper returning the DB header file.
 
         Return:
@@ -423,7 +497,7 @@ class Database:
         """
         return f"{self._name}/header.xml"
 
-    def poolFile(self) -> str:
+    def pool_file(self) -> str:
         """Helper returning the DB trajectory pool file.
 
         Return:
@@ -431,15 +505,15 @@ class Database:
         """
         return f"{self._name}/trajPool.db"
 
-    def isEmpty(self) -> bool:
+    def is_empty(self) -> bool:
         """Check if list of trajectories is empty.
 
         Return:
             True if the list of trajectories is empty
         """
-        return self.trajListLen() == 0
+        return self.traj_list_len() == 0
 
-    def trajListLen(self) -> int:
+    def traj_list_len(self) -> int:
         """Length of the trajectory list.
 
         Return:
@@ -447,8 +521,8 @@ class Database:
         """
         return len(self._trajs_db)
 
-    def updateTrajList(self,
-                       a_trajList: list[Trajectory]) -> None:
+    def update_traj_list(self,
+                         a_trajList: list[Trajectory]) -> None:
         """Overwrite the trajectory list.
 
         Args:
@@ -456,11 +530,45 @@ class Database:
         """
         self._trajs_db = a_trajList
 
+    def lock_trajectory(self,
+                        tid: int,
+                        allow_completed_lock : bool = False) -> bool:
+        """Lock a trajectory in the SQL DB.
+
+        Args:
+            tid: the trajectory id
+            allow_completed_lock: True if the trajectory can be locked even if it is completed
+
+        Return:
+            True if no disk DB and the trajectory was locked
+        """
+        if not self._save:
+            return True
+        return self._pool_db.lock_trajectory(tid, allow_completed_lock)
+
+    def unlock_trajectory(self,
+                          tid: int,
+                          hasEnded: bool) -> None:
+        """Unlock a trajectory in the SQL DB.
+
+        Args:
+            tid: the trajectory id
+            hasEnded: True if the trajectory has ended
+        """
+        if not self._save:
+            return
+
+        if hasEnded:
+            self._pool_db.mark_trajectory_as_completed(tid)
+        else:
+            self._pool_db.release_trajectory(tid)
+
+
     def weights(self) -> list[float]:
         """Splitting iterations weights."""
         return  self._weights
 
-    def appendWeight(self, weight: float) -> None:
+    def append_weight(self, weight: float) -> None:
         """Append a weight to internal list."""
         self._weights.append(weight)
 
@@ -468,13 +576,17 @@ class Database:
         """Splitting iterations biases."""
         return self._l_bias
 
-    def appendBias(self, bias: int) -> None:
+    def append_bias(self, bias: int) -> None:
         """Append a bias to internal list."""
         self._l_bias.append(bias)
 
     def kSplit(self) -> int:
         """Splitting iteration counter."""
         return self._ksplit
+
+    def done_with_splitting(self) -> bool:
+        """Check if we are done with splitting."""
+        return self._ksplit >= self._nsplititer
 
     def reset_ongoing(self) -> None:
         """Reset the list of trajectories undergoing branching."""
@@ -488,7 +600,7 @@ class Database:
         """Set splitting iteration counter."""
         self._ksplit = ksplit
 
-    def countEndedTraj(self) -> int:
+    def count_ended_traj(self) -> int:
         """Return the number of trajectories that ended."""
         count = 0
         for T in self._trajs_db:
@@ -496,7 +608,7 @@ class Database:
                 count = count + 1
         return count
 
-    def countConvergedTraj(self) -> int:
+    def count_converged_traj(self) -> int:
         """Return the number of trajectories that converged."""
         count = 0
         for T in self._trajs_db:
@@ -504,9 +616,9 @@ class Database:
                 count = count + 1
         return count
 
-    def getTransitionProbability(self) -> float:
+    def get_transition_probability(self) -> float:
         """Return the transition probability."""
-        if self.countEndedTraj() < self._ntraj:
+        if self.count_ended_traj() < self._ntraj:
             print("TAMS initialization still ongoing, probability estimate not available yet")
             return 0.0
         else:
@@ -514,33 +626,32 @@ class Database:
             for i in range(len(self._l_bias)):
                 W += self._l_bias[i] * self._weights[i]
 
-            trans_prob = self.countConvergedTraj() * self._weights[-1] / W
+            trans_prob = self.count_converged_traj() * self._weights[-1] / W
             return trans_prob
 
 
     def info(self) -> None:
         """Print database info to screen."""
-        version, db_date, db_model = self._readHeader()
-        db_date_str = str(db_date)
+        db_date_str = str(self._creation_date)
         prettyLine = "####################################################"
         inf_tbl = f"""
             {prettyLine}
-            # TAMS v{version:17s} trajectory database      #
+            # TAMS v{self._version:17s} trajectory database      #
             # Date: {db_date_str:42s} #
-            # Model: {db_model:41s} #
+            # Model: {self._fmodel_t.name():41s} #
             {prettyLine}
             # Requested # of traj: {self._ntraj:27} #
             # Requested # of splitting iter: {self._nsplititer:17} #
-            # Number of 'Ended' trajectories: {self.countEndedTraj():16} #
-            # Number of 'Converged' trajectories: {self.countConvergedTraj():12} #
+            # Number of 'Ended' trajectories: {self.count_ended_traj():16} #
+            # Number of 'Converged' trajectories: {self.count_converged_traj():12} #
             # Current splitting iter counter: {self._ksplit:16} #
-            # Transition probability: {self.getTransitionProbability():24} #
+            # Transition probability: {self.get_transition_probability():24} #
             {prettyLine}
         """
         print(inf_tbl)
 
-    def plotScoreFunctions(self,
-                           fname: Optional[str] = None) -> None:
+    def plot_score_functions(self,
+                             fname: Optional[str] = None) -> None:
         """Plot the score as function of time for all trajectories."""
         if not fname:
             pltfile = Path(self._name).stem + "_scores.png"

--- a/pytams/database.py
+++ b/pytams/database.py
@@ -13,7 +13,6 @@ from typing import Any
 from typing import Optional
 from typing import Union
 import cloudpickle
-import dill
 import matplotlib.pyplot as plt
 import numpy as np
 import toml
@@ -168,7 +167,7 @@ class Database:
             db_params["database"]["path"] = str(a_path)
         model_file = Path(a_path / "fmodel.pkl")
         with model_file.open("rb") as f:
-            model = dill.load(f)
+            model = cloudpickle.load(f)
 
         return cls(model, db_params)
 

--- a/pytams/fmodel.py
+++ b/pytams/fmodel.py
@@ -1,6 +1,8 @@
 """A base class for the stochastic forward model."""
+import os
 from abc import ABCMeta
 from abc import abstractmethod
+from pathlib import Path
 from typing import Any
 from typing import Optional
 from typing import final
@@ -33,12 +35,14 @@ class ForwardModelBaseClass(metaclass=ABCMeta):
         _noise: the noise to be used in the next model step
         _step: the current stochastic step counter
         _time: the current stochastic time
+        _workdir: the working directory
     """
 
     @final
     def __init__(self,
                  params: dict,
-                 ioprefix: Optional[str] = None):
+                 ioprefix: Optional[str] = None,
+                 workdir: Optional[os.PathLike] = None):
         """Base class __init__ method.
 
         The ABC init method calls the concrete class init method
@@ -51,14 +55,16 @@ class ForwardModelBaseClass(metaclass=ABCMeta):
         is made to ensure the proper type is generated.
 
         Args:
-            params: an optional dict containing parameters
+            params: a dict containing parameters
             ioprefix: an optional string defining run folder
+            workdir: an optional path to the working directory
         """
         # Initialize common tooling
         self._prescribed_noise : bool = False
         self._noise : Any = None
         self._step : int = 0
         self._time : float = 0.0
+        self._workdir : os.PathLike = Path.cwd() if workdir is None else workdir
 
         # Add the deterministic parameter to the model dictionary
         # for clarity
@@ -131,6 +137,15 @@ class ForwardModelBaseClass(metaclass=ABCMeta):
     def clear(self) -> None:
         """Destroy internal data."""
         self._clear_model()
+
+    @final
+    def setWorkDir(self, workdir : os.PathLike) -> None:
+        """Setter of the model working directory.
+
+        Args:
+            workdir: the new working directory
+        """
+        self._workdir = workdir
 
     @abstractmethod
     def _init_model(self,

--- a/pytams/trajectory.py
+++ b/pytams/trajectory.py
@@ -4,6 +4,7 @@ import os
 import time
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 from typing import Optional
 import numpy as np
@@ -104,7 +105,7 @@ class Trajectory:
         self._score_max : float = 0.0
 
         self._tid : int = trajId
-        self._checkFile : str = f"{self.idstr()}.xml"
+        self._checkFile : os.PathLike = Path(f"{self.idstr()}.xml")
 
         self._has_ended : bool = False
         self._has_converged : bool = False
@@ -112,9 +113,9 @@ class Trajectory:
         # Each trajectory have its own instance of the model
         self._fmodel = fmodel_t(parameters, self.idstr())
 
-    def setCheckFile(self, file: str) -> None:
+    def setCheckFile(self, path: os.PathLike) -> None:
         """Setter of the trajectory checkFile."""
-        self._checkFile = file
+        self._checkFile = path
 
     def id(self) -> int:
         """Return trajectory Id."""
@@ -226,15 +227,15 @@ class Trajectory:
     @classmethod
     def restoreFromChk(
         cls,
-        chkPoint: str,
+        chkPoint: os.PathLike,
         fmodel_t: Any,
         parameters: dict,
     ) -> Trajectory:
         """Return a trajectory restored from an XML chkfile."""
-        assert os.path.exists(chkPoint) is True
+        assert Path(chkPoint).exists() is True
 
         # Read in trajectory metadata
-        tree = ET.parse(chkPoint)
+        tree = ET.parse(chkPoint.absolute())
         root = tree.getroot()
         metadata = xml_to_dict(root.find("metadata"))
         t_id = metadata["id"]
@@ -302,6 +303,7 @@ class Trajectory:
                 parameters=traj._parameters_full,
                 trajId=rstId,
             )
+            restTraj.setCheckFile(traj.checkFile().parent / f"/{restTraj.idstr()}.xml")
             return restTraj
 
         # To ensure that TAMS converges, branching occurs on
@@ -319,6 +321,7 @@ class Trajectory:
         restTraj = Trajectory(
             fmodel_t=type(traj._fmodel), parameters=traj._parameters_full, trajId=rstId
         )
+        restTraj.setCheckFile(traj.checkFile().parent / f"{restTraj.idstr()}.xml")
 
         # Append snapshots, up to high_score_idx + 1 to
         # ensure > behavior
@@ -339,7 +342,7 @@ class Trajectory:
 
         return restTraj
 
-    def store(self, traj_file: Optional[str] = None) -> None:
+    def store(self, traj_file: Optional[os.PathLike] = None) -> None:
         """Store the trajectory to an XML chkfile."""
         root = ET.Element(self.idstr())
         root.append(dict_to_xml("params", self._parameters_full["trajectory"]))
@@ -363,9 +366,9 @@ class Trajectory:
         tree = ET.ElementTree(root)
         ET.indent(tree, space="\t", level=0)
         if traj_file is not None:
-            tree.write(traj_file)
+            tree.write(traj_file.absolute())
         else:
-            tree.write(self._checkFile)
+            tree.write(self._checkFile.absolute())
 
     def updateMetadata(self) -> None:
         """Update trajectory score/ending metadata."""
@@ -403,7 +406,7 @@ class Trajectory:
         """Return True if computation has started."""
         return self._t_cur > 0.0
 
-    def checkFile(self) -> str:
+    def checkFile(self) -> os.PathLike:
         """Return the trajectory check file name."""
         return self._checkFile
 

--- a/tests/test_tams.py
+++ b/tests/test_tams.py
@@ -4,7 +4,6 @@ import shutil
 import pytest
 import toml
 from pytams.tams import TAMS
-from pytams.tams import TAMSError
 from tests.models import DoubleWellModel
 from tests.models import SimpleFModel
 
@@ -30,7 +29,7 @@ def test_initTAMSMissingReq():
 def test_initTAMSNoInput():
     """Test failed TAMS initialization."""
     fmodel = SimpleFModel
-    with pytest.raises(TAMSError):
+    with pytest.raises(ValueError):
         _ = TAMS(fmodel_t=fmodel, a_args=["-i", "dummy.toml"])
 
 def test_simpleModelTAMS():

--- a/tests/test_tams.py
+++ b/tests/test_tams.py
@@ -50,8 +50,8 @@ def test_simpleModelTAMSwithDB():
     fmodel = SimpleFModel
     with open("input.toml", 'w') as f:
         toml.dump({"tams": {"ntrajectories": 100, "nsplititer": 200, "loglevel": "WARNING"},
-                   "runner": {"type" : "asyncio"},
-                   "database" : {"DB_save" : True, "DB_prefix" : "simpleModelTest"},
+                   "runner": {"type" : "dask"},
+                   "database" : {"path" : "simpleModelTest.tdb"},
                    "trajectory": {"end_time": 0.02, "step_size": 0.001, "targetscore": 0.15,
                                   "chkfile_dump_all" : True}}, f)
     tams = TAMS(fmodel_t=fmodel, a_args=[])
@@ -79,7 +79,7 @@ def test_simpleModelTwiceTAMS():
         toml.dump({"tams": {"ntrajectories": 100, "nsplititer": 200, "loglevel": "WARNING",
                             "logfile": "test.log"},
                    "runner": {"type" : "asyncio"},
-                   "database" : {"DB_save" : True, "DB_prefix" : "simpleModelTest"},
+                   "database" : {"path" : "simpleModelTest.tdb", "restart" : True},
                    "trajectory": {"end_time": 0.02, "step_size": 0.001, "targetscore": 0.15}}, f)
     tams = TAMS(fmodel_t=fmodel, a_args=[])
     transition_proba = tams.compute_probability()
@@ -129,7 +129,7 @@ def test_doublewellModelSaveTAMS():
     with open("input.toml", 'w') as f:
         toml.dump({"tams": {"ntrajectories": 50, "nsplititer": 100, "walltime": 500.0},
                    "runner": {"type" : "dask"},
-                   "database": {"DB_save": True, "DB_prefix": "dwTest"},
+                   "database": {"path": "dwTest.tdb"},
                    "trajectory": {"end_time": 10.0, "step_size": 0.01,
                                   "targetscore": 0.3, "stoichforcing" : 0.8}}, f)
     tams = TAMS(fmodel_t=fmodel, a_args=[])
@@ -161,8 +161,8 @@ def test_doublewellModel2WorkersTAMS():
     with open("input.toml", 'w') as f:
         toml.dump({"tams": {"ntrajectories": 100, "nsplititer": 400,
                             "walltime": 500.0, "deterministic": True},
-                   "runner": {"type" : "asyncio", "nworker_init": 2, "nworker_iter": 2},
-                   "database": {"DB_save": True, "DB_prefix": "dwTest"},
+                   "runner": {"type" : "dask", "nworker_init": 2, "nworker_iter": 2},
+                   "database": {"path": "dwTest.tdb"},
                    "trajectory": {"end_time": 10.0, "step_size": 0.01,
                                   "targetscore": 0.6, "stoichforcing" : 0.8}}, f)
     tams = TAMS(fmodel_t=fmodel, a_args=[])
@@ -177,8 +177,7 @@ def test_doublewellModel2WorkersRestoreTAMS():
     fmodel = DoubleWellModel
     with open("input.toml", 'w') as f:
         toml.dump({"tams": {"ntrajectories": 100, "nsplititer": 400, "walltime": 500.0},
-                   "database": {"DB_save": True, "DB_prefix": "dwTest",
-                                "DB_restart": "dwTest.tdb"},
+                   "database": {"path": "dwTest.tdb"},
                    "runner": {"type" : "asyncio", "nworker_init": 2, "nworker_iter": 2},
                    "trajectory": {"end_time": 10.0, "step_size": 0.01,
                                   "targetscore": 0.6, "stoichforcing" : 0.8}}, f)
@@ -193,8 +192,8 @@ def test_doublewellVerySlowTAMS():
     """Test TAMS run out of time with a slow doublewell."""
     fmodel = DoubleWellModel
     with open("input.toml", 'w') as f:
-        toml.dump({"tams": {"ntrajectories": 5, "nsplititer": 400, "walltime": 10.0},
-                   "database": {"DB_save": True, "DB_prefix": "dwTest"},
+        toml.dump({"tams": {"ntrajectories": 5, "nsplititer": 400, "walltime": 6.0},
+                   "database": {"path": "dwTest.tdb"},
                    "runner": {"type" : "dask", "nworker_init": 1, "nworker_iter": 1},
                    "trajectory": {"end_time": 10.0, "step_size": 0.01,
                                   "targetscore": 0.7, "stoichforcing" : 0.1},
@@ -211,8 +210,8 @@ def test_doublewellSlowTAMS():
     """Test TAMS run out of time with a slow doublewell."""
     fmodel = DoubleWellModel
     with open("input.toml", 'w') as f:
-        toml.dump({"tams": {"ntrajectories": 5, "nsplititer": 400, "walltime": 10.0},
-                   "database": {"DB_save": True, "DB_prefix": "dwTest"},
+        toml.dump({"tams": {"ntrajectories": 5, "nsplititer": 400, "walltime": 6.0},
+                   "database": {"path": "dwTest.tdb"},
                    "runner": {"type" : "asyncio", "nworker_init": 1, "nworker_iter": 1},
                    "trajectory": {"end_time": 10.0, "step_size": 0.01,
                                   "targetscore": 0.7, "stoichforcing" : 0.1},
@@ -228,9 +227,8 @@ def test_doublewellSlowRestoreTAMS():
     """Test TAMS restarting a slow doublewell."""
     fmodel = DoubleWellModel
     with open("input.toml", 'w') as f:
-        toml.dump({"tams": {"ntrajectories": 5, "nsplititer": 400, "walltime": 10.0},
-                   "database": {"DB_save": True, "DB_prefix": "dwTest",
-                                "DB_restart": "dwTest.tdb"},
+        toml.dump({"tams": {"ntrajectories": 5, "nsplititer": 400, "walltime": 6.0},
+                   "database": {"path": "dwTest.tdb"},
                    "runner": {"type" : "asyncio", "nworker_init": 1, "nworker_iter": 1},
                    "trajectory": {"end_time": 10.0, "step_size": 0.01,
                                   "targetscore": 0.7, "stoichforcing" : 0.1},

--- a/tests/test_trajectory.py
+++ b/tests/test_trajectory.py
@@ -1,6 +1,6 @@
 """Tests for the pytams.trajectory class."""
-import os
 from math import isclose
+from pathlib import Path
 import pytest
 from pytams.fmodel import ForwardModelBaseClass
 from pytams.trajectory import Snapshot
@@ -86,12 +86,14 @@ def test_storeAndRestoreSimpleTraj():
     t_test.advance(0.02)
     assert isclose(t_test.scoreMax(), 0.2, abs_tol=1e-9)
     assert t_test.isConverged() is False
-    t_test.store("test.xml")
-    assert os.path.exists("test.xml") is True
-    rst_test = Trajectory.restoreFromChk("test.xml", fmodel, parameters)
+    chkFile = Path("./test.xml")
+    t_test.store(chkFile)
+    assert chkFile.exists() is True
+    rst_test = Trajectory.restoreFromChk(chkFile, fmodel, parameters)
     assert isclose(rst_test.scoreMax(), 0.2, abs_tol=1e-9)
     rst_test.advance()
     assert rst_test.isConverged() is True
+    chkFile.unlink()
 
 
 def test_restartSimpleTraj():
@@ -145,12 +147,13 @@ def test_storeAndRestartSparseSimpleTraj():
     t_test.advance(0.013)
     assert isclose(t_test.scoreMax(), 0.13, abs_tol=1e-9)
     assert t_test.isConverged() is False
-    t_test.store("test.xml")
-    assert os.path.exists("test.xml") is True
-    rst_test = Trajectory.restoreFromChk("test.xml", fmodel, parameters)
+    chkFile = Path("./test.xml")
+    t_test.store(chkFile)
+    assert chkFile.exists() is True
+    rst_test = Trajectory.restoreFromChk(chkFile, fmodel, parameters)
     rst_test.advance()
     assert rst_test.isConverged() is True
-    os.remove("test.xml")
+    chkFile.unlink()
 
 def test_scoreMovingAverage():
     """Test using a moving average on a score array."""

--- a/tests/test_trajectory.py
+++ b/tests/test_trajectory.py
@@ -27,7 +27,7 @@ def test_initBaseClassError():
     fmodel = ForwardModelBaseClass
     parameters = {}
     with pytest.raises(Exception):
-        _ = Trajectory(fmodel, parameters, 1)
+        _ = Trajectory(1, fmodel, parameters)
 
 
 def test_initBlankTraj():
@@ -35,7 +35,7 @@ def test_initBlankTraj():
     fmodel = SimpleFModel
     parameters = {"trajectory" : {"end_time": 2.0,
                                   "step_size": 0.01}}
-    t_test = Trajectory(fmodel, parameters, 1)
+    t_test = Trajectory(1, fmodel, parameters)
     assert t_test.id() == 1
     assert t_test.idstr() == "traj000001"
     assert t_test.ctime() == 0.0
@@ -48,7 +48,7 @@ def test_initParametrizedTraj():
     parameters = {"trajectory" : {"end_time": 2.0,
                                   "step_size": 0.01,
                                   "targetscore": 0.25}}
-    t_test = Trajectory(fmodel, parameters, 1)
+    t_test = Trajectory(1, fmodel, parameters)
     assert t_test.stepSize() == 0.01
 
 
@@ -57,8 +57,9 @@ def test_restartEmptyTraj():
     fmodel = SimpleFModel
     parameters = {"trajectory" : {"end_time": 2.0,
                                   "step_size": 0.01}}
-    t_test = Trajectory(fmodel, parameters, 1)
-    rst_test = Trajectory.restartFromTraj(t_test, 2, 0.1)
+    fromTraj = Trajectory(1, fmodel, parameters)
+    rstTraj = Trajectory(2, fmodel, parameters)
+    rst_test = Trajectory.restartFromTraj(fromTraj, rstTraj, 0.1)
     assert rst_test.ctime() == 0.0
 
 
@@ -68,7 +69,7 @@ def test_simpleModelTraj():
     parameters = {"trajectory" : {"end_time": 0.04,
                                   "step_size": 0.001,
                                   "targetscore": 0.25}}
-    t_test = Trajectory(fmodel, parameters, 1)
+    t_test = Trajectory(1, fmodel, parameters)
     t_test.advance(0.01)
     assert isclose(t_test.scoreMax(), 0.1, abs_tol=1e-9)
     assert t_test.isConverged() is False
@@ -82,7 +83,7 @@ def test_storeAndRestoreSimpleTraj():
     parameters = {"trajectory" : {"end_time": 0.05,
                                   "step_size": 0.001,
                                   "targetscore": 0.25}}
-    t_test = Trajectory(fmodel, parameters, 1)
+    t_test = Trajectory(1, fmodel, parameters)
     t_test.advance(0.02)
     assert isclose(t_test.scoreMax(), 0.2, abs_tol=1e-9)
     assert t_test.isConverged() is False
@@ -102,9 +103,10 @@ def test_restartSimpleTraj():
     parameters = {"trajectory" : {"end_time": 0.04,
                                   "step_size": 0.001,
                                   "targetscore": 0.25}}
-    t_test = Trajectory(fmodel, parameters, 1)
-    t_test.advance(0.01)
-    rst_test = Trajectory.restartFromTraj(t_test, 2, 0.05)
+    fromTraj = Trajectory(1, fmodel, parameters)
+    fromTraj.advance(0.01)
+    rstTraj = Trajectory(2, fmodel, parameters)
+    rst_test = Trajectory.restartFromTraj(fromTraj, rstTraj, 0.05)
     assert rst_test.ctime() == 0.006
 
 
@@ -114,7 +116,7 @@ def test_accessDataSimpleTraj():
     parameters = {"trajectory" : {"end_time": 0.04,
                                   "step_size": 0.001,
                                   "targetscore": 0.25}}
-    t_test = Trajectory(fmodel, parameters, 1)
+    t_test = Trajectory(1, fmodel, parameters)
     t_test.advance(0.01)
     assert t_test.getLength() == 11
     assert isclose(t_test.getTimeArr()[-1], 0.01, abs_tol=1e-9)
@@ -127,7 +129,7 @@ def test_sparseSimpleTraj():
                                   "step_size": 0.001,
                                   "targetscore": 0.25,
                                   "sparse_freq": 5}}
-    t_test = Trajectory(fmodel, parameters, 1)
+    t_test = Trajectory(1, fmodel, parameters)
     t_test.advance(0.012)
     assert isclose(t_test.scoreMax(), 0.12, abs_tol=1e-9)
     assert t_test.isConverged() is False
@@ -143,7 +145,7 @@ def test_storeAndRestartSparseSimpleTraj():
                                   "step_size": 0.001,
                                   "targetscore": 0.25,
                                   "sparse_freq": 5}}
-    t_test = Trajectory(fmodel, parameters, 1)
+    t_test = Trajectory(1, fmodel, parameters)
     t_test.advance(0.013)
     assert isclose(t_test.scoreMax(), 0.13, abs_tol=1e-9)
     assert t_test.isConverged() is False
@@ -161,7 +163,7 @@ def test_scoreMovingAverage():
     parameters = {"trajectory" : {"end_time": 0.9,
                                   "step_size": 0.0001,
                                   "targetscore": 0.95}}
-    t_test = Trajectory(fmodel, parameters, 1)
+    t_test = Trajectory(1, fmodel, parameters)
     t_test.advance()
     score = t_test.getScoreArr()
     avg_score = moving_avg(score, 10)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -20,7 +20,7 @@ def test_run_pool_worker():
                                   "targetscore": 0.25}}
     t_test = Trajectory(fmodel, parameters, 1)
     enddate = datetime.datetime.utcnow() + datetime.timedelta(seconds=10.0)
-    t_test = pool_worker(t_test, enddate, False, "testDB")
+    t_test = pool_worker(t_test, enddate)
     assert isclose(t_test.scoreMax(), 0.1, abs_tol=1e-9)
     assert t_test.isConverged() is False
 
@@ -35,7 +35,7 @@ def test_run_pool_worker_outoftime(caplog : pytest.LogCaptureFixture):
     setup_logger(parameters)
     t_test = Trajectory(fmodel, parameters, 1)
     enddate = datetime.datetime.utcnow() + datetime.timedelta(seconds=0.1)
-    _ = pool_worker(t_test, enddate, False, "testDB")
+    _ = pool_worker(t_test, enddate)
     assert "advance ran out of time" in caplog.text
 
 def test_run_pool_worker_advanceerror():
@@ -49,7 +49,7 @@ def test_run_pool_worker_advanceerror():
     enddate = datetime.datetime.utcnow() + datetime.timedelta(seconds=1.0)
     t_test = Trajectory(fmodel, parameters, 1)
     with pytest.raises(RuntimeError):
-        _ = pool_worker(t_test, enddate, False, "testDB")
+        _ = pool_worker(t_test, enddate)
 
 def test_run_ms_worker():
     """Branch and advance trajectory through ms_worker."""
@@ -62,8 +62,7 @@ def test_run_ms_worker():
     t_test.advance()
     b_test = ms_worker(t_test,
                        2, 0.049,
-                       enddate,
-                       False, "testDB")
+                       enddate)
     assert b_test.id() == 2
     assert isclose(b_test.scoreMax(), 0.1, abs_tol=1e-9)
     assert b_test.isConverged() is False
@@ -82,8 +81,7 @@ def test_run_ms_worker_outoftime(caplog : pytest.LogCaptureFixture):
     enddate = datetime.datetime.utcnow() + datetime.timedelta(seconds=0.1)
     _ = ms_worker(t_test,
                   2, 0.1,
-                  enddate,
-                  False, "testDB")
+                  enddate)
     assert "advance ran out of time" in caplog.text
 
 def test_run_ms_worker_advanceerror():
@@ -100,5 +98,4 @@ def test_run_ms_worker_advanceerror():
     with pytest.raises(RuntimeError):
         _ = ms_worker(t_test,
                       5, 0.04,
-                      enddate,
-                      False, "testDB")
+                      enddate)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -18,7 +18,7 @@ def test_run_pool_worker():
     parameters = {"trajectory" : {"end_time": 0.01,
                                   "step_size": 0.001,
                                   "targetscore": 0.25}}
-    t_test = Trajectory(fmodel, parameters, 1)
+    t_test = Trajectory(1, fmodel, parameters)
     enddate = datetime.datetime.utcnow() + datetime.timedelta(seconds=10.0)
     t_test = pool_worker(t_test, enddate)
     assert isclose(t_test.scoreMax(), 0.1, abs_tol=1e-9)
@@ -33,7 +33,7 @@ def test_run_pool_worker_outoftime(caplog : pytest.LogCaptureFixture):
                   "tams": {"loglevel": "DEBUG"},
                   "model": {"slow_factor": 0.003}}
     setup_logger(parameters)
-    t_test = Trajectory(fmodel, parameters, 1)
+    t_test = Trajectory(1, fmodel, parameters)
     enddate = datetime.datetime.utcnow() + datetime.timedelta(seconds=0.1)
     _ = pool_worker(t_test, enddate)
     assert "advance ran out of time" in caplog.text
@@ -47,7 +47,7 @@ def test_run_pool_worker_advanceerror():
                   "tams": {"loglevel": "DEBUG"}}
     setup_logger(parameters)
     enddate = datetime.datetime.utcnow() + datetime.timedelta(seconds=1.0)
-    t_test = Trajectory(fmodel, parameters, 1)
+    t_test = Trajectory(1, fmodel, parameters)
     with pytest.raises(RuntimeError):
         _ = pool_worker(t_test, enddate)
 
@@ -58,10 +58,11 @@ def test_run_ms_worker():
                                   "step_size": 0.001,
                                   "targetscore": 0.25}}
     enddate = datetime.datetime.utcnow() + datetime.timedelta(seconds=10.0)
-    t_test = Trajectory(fmodel, parameters, 1)
+    t_test = Trajectory(1, fmodel, parameters)
     t_test.advance()
+    rst_test = Trajectory(2, fmodel, parameters)
     b_test = ms_worker(t_test,
-                       2, 0.049,
+                       rst_test, 0.049,
                        enddate)
     assert b_test.id() == 2
     assert isclose(b_test.scoreMax(), 0.1, abs_tol=1e-9)
@@ -76,11 +77,12 @@ def test_run_ms_worker_outoftime(caplog : pytest.LogCaptureFixture):
                   "tams": {"loglevel": "DEBUG"},
                   "model": {"slow_factor": 0.003}}
     setup_logger(parameters)
-    t_test = Trajectory(fmodel, parameters, 1)
+    t_test = Trajectory(1, fmodel, parameters)
     t_test.advance()
+    rst_test = Trajectory(2, fmodel, parameters)
     enddate = datetime.datetime.utcnow() + datetime.timedelta(seconds=0.1)
     _ = ms_worker(t_test,
-                  2, 0.1,
+                  rst_test, 0.1,
                   enddate)
     assert "advance ran out of time" in caplog.text
 
@@ -93,9 +95,10 @@ def test_run_ms_worker_advanceerror():
                   "tams": {"loglevel": "DEBUG"}}
     enddate = datetime.datetime.utcnow() + datetime.timedelta(seconds=1.0)
     setup_logger(parameters)
-    t_test = Trajectory(fmodel, parameters, 1)
+    t_test = Trajectory(1, fmodel, parameters)
     t_test.advance(0.01)
+    rst_test = Trajectory(5, fmodel, parameters)
     with pytest.raises(RuntimeError):
         _ = ms_worker(t_test,
-                      5, 0.04,
+                      rst_test, 0.04,
                       enddate)


### PR DESCRIPTION
 - Further detach the database from the algorithm.
 - Enforce methods naming convention.
 - Work with the `pathlib` library to better handle path and location.
 - Database internal do not include the path to the database, making it easier to copy and move the DB around.

- [x] Pass a work directory to the model

Address #48 