### PR TITLE
Open-ended traj

### DIFF
--- a/pytams/database.py
+++ b/pytams/database.py
@@ -665,17 +665,17 @@ class Database(Generic[T_Noise, T_State]):
         """
         return self._pool_db.lock_trajectory(tid, allow_completed_lock)
 
-    def unlock_trajectory(self, tid: int, has_ended: bool) -> None:
+    def unlock_trajectory(self, tid: int, has_terminated: bool) -> None:
         """Unlock a trajectory in the SQL DB.
 
         Args:
             tid: the trajectory id
-            has_ended: True if the trajectory has ended
+            has_terminated: True if the trajectory has terminated
 
         Raises:
             SQLAlchemyError if the DB could not be accessed
         """
-        if has_ended:
+        if has_terminated:
             self._pool_db.mark_trajectory_as_completed(tid)
         else:
             self._pool_db.release_trajectory(tid)
@@ -870,9 +870,9 @@ class Database(Generic[T_Noise, T_State]):
         """
         return self._init_ensemble_done
 
-    def count_ended_traj(self) -> int:
-        """Return the number of trajectories that ended."""
-        return self._pool_db.get_ended_trajectory_count()
+    def count_terminated_traj(self) -> int:
+        """Return the number of trajectories that terminated."""
+        return self._pool_db.get_terminated_trajectory_count()
 
     def count_converged_traj(self) -> int:
         """Return the number of trajectories that converged."""
@@ -892,7 +892,7 @@ class Database(Generic[T_Noise, T_State]):
 
     def get_transition_probability(self) -> float:
         """Return the transition probability."""
-        if self.count_ended_traj() < self._ntraj:
+        if self.count_terminated_traj() < self._ntraj:
             return 0.0
 
         # Insert a first element to the weight array
@@ -917,7 +917,7 @@ class Database(Generic[T_Noise, T_State]):
             {pretty_line}
             # Requested # of traj: {self._ntraj:27} #
             # Requested # of splitting iter: {self._nsplititer:17} #
-            # Number of 'Ended' trajectories: {self.count_ended_traj():16} #
+            # Number of 'Terminated' trajectories: {self.count_terminated_traj():10} #
             # Number of 'Converged' trajectories: {self.count_converged_traj():12} #
             # Current splitting iter counter: {self.k_split():16} #
             # Current total number of steps: {self.count_computed_steps():17} #

--- a/pytams/fmodel.py
+++ b/pytams/fmodel.py
@@ -264,6 +264,25 @@ class ForwardModelBaseClass(ABC, Generic[T_Noise, T_State]):
         _ = (step, time)
         return current_score >= target_score
 
+    def check_termination(self, step: int, time: float, nstep_end: int, time_end: float, current_score: float) -> bool:
+        """Check if the trajectory is terminated.
+
+        This default implementation checks if the current time or
+        step is below the provided end time and end step.
+        This is proper when running TAMS sampling, but not AMS or other methods.
+
+        Args:
+            step: the current step counter
+            time: the time of the simulation
+            nstep_end: the maximum number of steps to advance
+            time_end: the end time of the advance
+            current_score: the current score
+        """
+        _ = current_score
+        step_termination = step >= nstep_end if nstep_end > 0 else False
+        time_termination = time >= time_end if time_end > 0.0 else False
+        return step_termination or time_termination
+
     def _clear_model(self) -> Any:
         """Clear the concrete forward model internals."""
 

--- a/pytams/tams.py
+++ b/pytams/tams.py
@@ -199,7 +199,7 @@ class TAMS:
         t_list.sort(key=lambda t: t.id())
         self._tdb.update_traj_list(t_list)
 
-        if self._tdb.count_ended_traj() == self._tdb.n_traj():
+        if self._tdb.count_terminated_traj() == self._tdb.n_traj():
             self._tdb.set_init_ensemble_flag(True)
 
         inf_msg = f"Run time: {self.elapsed_time()} s"
@@ -247,7 +247,7 @@ class TAMS:
         """Check and finish unfinished splitting iterations.
 
         If the run was interrupted during a splitting iteration,
-        the branched trajectories might not have ended yet. In that case,
+        the branched trajectories might not have terminated yet. In that case,
         a list of trajectories to finish is listed in the database.
         """
         # Check the database for unfinished splitting iteration when restarting.

--- a/pytams/trajdb.py
+++ b/pytams/trajdb.py
@@ -230,10 +230,10 @@ class TrajDB(BaseSQLManager):
         with self.session_scope() as session:
             return session.scalar(select(func.count(Trajectory.id))) or 0
 
-    def get_ended_trajectory_count(self) -> int:
-        """Return the number of trajectories that have 'ended' in their metadata."""
+    def get_terminated_trajectory_count(self) -> int:
+        """Return the number of trajectories that have 'terminated' in their metadata."""
         with self.session_scope() as session:
-            stmt = select(func.count(Trajectory.id)).where(Trajectory.t_metadata["ended"].as_boolean())
+            stmt = select(func.count(Trajectory.id)).where(Trajectory.t_metadata["terminated"].as_boolean())
             return session.scalar(stmt) or 0
 
     def get_converged_trajectory_count(self) -> int:

--- a/pytams/trajectory.py
+++ b/pytams/trajectory.py
@@ -1,3 +1,5 @@
+"""A trajectory class for individual MCMC runs."""
+
 from __future__ import annotations
 import copy
 import json
@@ -62,11 +64,13 @@ def get_index_from_id(identity: str) -> tuple[int, int]:
 class Trajectory(Generic[T_Noise, T_State]):
     """A class defining a stochastic trajectory.
 
+    Each trajectory is a MCMC simulation of the forward model.
+
     The trajectory class is a container for time-ordered snapshots.
     It contains an instance of the forward model, current and end times, and
     a list of the model snapshots. Note that the class uses a plain list of snapshots
     and not a more computationally efficient data structure such as a numpy array
-    for convenience. It is assumed that the computational cost of running TAMS
+    for convenience. It is assumed that the computational cost of running the sampling algorithm
     resides in the forward model and the overhead of the trajectory class is negligible.
 
     It also provide the forward model with the necessary context to advance in time,
@@ -105,7 +109,7 @@ class Trajectory(Generic[T_Noise, T_State]):
         workdir: Path | None = None,
         frozen: bool = False,
     ) -> None:
-        """Create a trajectory.
+        """Initialize a trajectory.
 
         Args:
             traj_id: a int for the trajectory index
@@ -118,9 +122,10 @@ class Trajectory(Generic[T_Noise, T_State]):
         # Stash away the full parameters dict
         self._parameters_full: dict[Any, Any] = parameters
 
+        # Check that the step size is provided
         traj_params = parameters.get("trajectory", {})
-        if "end_time" not in traj_params or "step_size" not in traj_params:
-            err_msg = "Trajectory 'end_time' and 'step_size' must be specified in the input file !"
+        if "step_size" not in traj_params:
+            err_msg = "Trajectory 'step_size' must be specified in the input file !"
             _logger.error(err_msg)
             raise ValueError
 
@@ -128,17 +133,17 @@ class Trajectory(Generic[T_Noise, T_State]):
         self._tid: int = traj_id
         self._workdir: Path = Path.cwd() if workdir is None else workdir
         self._score_max: float = -1.0e12
-        self._has_ended: bool = False
         self._has_converged: bool = False
+        self._has_terminated: bool = False
         self._computed_steps: int = 0
         self._weight: float = weight
 
-        # TAMS is expected to start at t = 0.0, but the forward model
+        # Sampling is expected to start at t = 0.0, but the forward model
         # itself can have a different internal starting point
         # or an entirely different time scale.
         self._step: int = 0
         self._t_cur: float = 0.0
-        self._t_end: float = traj_params.get("end_time")
+        self._t_end: float = traj_params.get("end_time", -1.0)
         self._dt: float = traj_params.get("step_size")
 
         # Trajectory convergence is defined by a target score, with
@@ -153,8 +158,8 @@ class Trajectory(Generic[T_Noise, T_State]):
         # steps might be already available. This backlog is used to store them.
         self.noise_backlog: list[T_Noise] = []
 
-        # Keep track of the branching history during TAMS
-        # iterations
+        # Keep track of the branching history for iterative
+        # sampling algorithms
         self._branching_history: list[int] = []
 
         # For large models, the state may not be available at each snapshot due
@@ -239,7 +244,7 @@ class Trajectory(Generic[T_Noise, T_State]):
         """
         return form_trajectory_id(self._tid, self.get_nbranching())
 
-    def advance(self, t_end: float = 1.0e12, walltime: float = 1.0e12) -> None:
+    def advance(self, nstep_end: int = -1, t_end: float = -1.0, walltime: float = 1.0e12) -> None:
         """Advance the trajectory to a prescribed end time.
 
         This is the main time loop of the trajectory object.
@@ -251,6 +256,7 @@ class Trajectory(Generic[T_Noise, T_State]):
         TAMS workers.
 
         Args:
+            nstep_end: the number of steps to advance
             t_end: the end time of the advance
             walltime: a walltime limit to advance the model to t_end
 
@@ -261,34 +267,40 @@ class Trajectory(Generic[T_Noise, T_State]):
             WallTimeLimitError: if the walltime limit is reached
             RuntimeError: if the model advance run into a problem
         """
-        start_time = time.monotonic()
-        remaining_time = walltime - time.monotonic() + start_time
-        end_time = min(t_end, self._t_end)
-
+        # Check if the trajectory is frozen
         if not self._fmodel:
             err_msg = f"Trajectory {self.idstr()} is frozen, without forward model. Advance() deactivated."
             _logger.error(err_msg)
             raise RuntimeError(err_msg)
 
-        while self._t_cur < end_time and not self._has_converged and remaining_time >= 0.05 * walltime:
-            # Do a single step and keep track of remaining walltime
-            _ = self._one_step()
+        start_time = time.monotonic()
+        end_time = self._calculate_end_time(t_end)
 
-            # Initialize diagnostic now, access to diagdb
-            # no longer needs to be pickled at this point
-            if not self._initialized_diags and self._has_diagnostics:
-                self._setup_diagnostics()
+        # Termination depends on runtime arguments of the advance function.
+        # Re-evaluate before we move forward.
+        # (A previous call to advance with other arguments might have switched the boolean)
+        self._has_terminated = self._fmodel.check_termination(self._step, self._t_cur, nstep_end, end_time, -1.0)
 
-            # Perform any diagnostic requested
-            for plugin in self._diagplugins:
-                plugin.update(self._snaps[-2], self._snaps[-1])
+        while not (self._has_terminated or self._has_converged):
+            # Do a single model step
+            score = self._one_step()
 
-            remaining_time = walltime - time.monotonic() + start_time
+            # Check for termination/convergence
+            self._has_converged = self._fmodel.check_convergence(self._step, self._t_cur, score, self._convergedVal)
+            self._has_terminated = self._fmodel.check_termination(self._step, self._t_cur, nstep_end, end_time, score)
 
-        if self._t_cur >= self._t_end or self._has_converged:
-            self._has_ended = True
+            # Handle diagnostics
+            self._update_diagnostics()
 
-        if self._has_ended:
+            # Check timeout before continuing
+            if (time.monotonic() - start_time) >= walltime:
+                break
+
+        # If the model has converged, terminate
+        if self._has_converged:
+            self._has_terminated = True
+
+        if self._has_terminated:
             self._fmodel.clear()
 
         # Clear the diagnostic
@@ -298,10 +310,35 @@ class Trajectory(Generic[T_Noise, T_State]):
             self._diagplugins = []
             self._initialized_diags = False
 
-        if remaining_time < 0.05 * walltime:
+        if (time.monotonic() - start_time) >= walltime:
             warn_msg = f"{self.idstr()} ran out of time in advance()"
             _logger.warning(warn_msg)
             raise WallTimeLimitError(warn_msg)
+
+    def _calculate_end_time(self, t_end: float) -> float:
+        """Returns the earliest positive end time, or -1.0 if none exist.
+
+        Args:
+            t_end: the end time of the advance
+
+        Returns:
+            the earliest positive end time
+        """
+        valid_times = [t for t in (self._t_end, t_end) if t > 0.0]
+        return min(valid_times) if valid_times else -1.0
+
+    def _update_diagnostics(self) -> None:
+        """Handle diagnostic initialization and plugin updates."""
+        if not self._has_diagnostics:
+            return
+
+        # Initialize diagnostic now, access to diagdb
+        # no longer needs to be pickled at this point
+        if not self._initialized_diags:
+            self._setup_diagnostics()
+
+        for plugin in self._diagplugins:
+            plugin.update(self._snaps[-2], self._snaps[-1])
 
     def _one_step(self) -> float:
         """Perform a single step of the forward model.
@@ -309,6 +346,10 @@ class Trajectory(Generic[T_Noise, T_State]):
         Perform a single time step of the forward model. This
         function will also set the noise to use for the next step
         in the forward model if a backlog is available.
+
+        Args:
+            nstep_end: the maximum number of steps to advance
+            t_end: the end time of the advance
         """
         if not self._fmodel:
             err_msg = f"Trajectory {self.idstr()} is frozen, without forward model. Advance() deactivated."
@@ -345,11 +386,6 @@ class Trajectory(Generic[T_Noise, T_State]):
             self.store()
 
         self._score_max = max(self._score_max, score)
-
-        # The default ABC method simply check for a score above
-        # the target value, but concrete implementations can override
-        # with mode complex convergence criteria
-        self._has_converged = self._fmodel.check_convergence(self._step, self._t_cur, score, self._convergedVal)
 
         # Increment the computed step counter
         self._computed_steps += 1
@@ -452,7 +488,7 @@ class Trajectory(Generic[T_Noise, T_State]):
         traj._t_cur = metadata["t_cur"]
         traj._dt = metadata["dt"]
         traj._score_max = metadata["score_max"]
-        traj._has_ended = metadata["ended"]
+        traj._has_terminated = metadata["terminated"]
         traj._has_converged = metadata["converged"]
         traj._branching_history = metadata["branching_history"]
         traj._computed_steps = metadata["nstep_compute"]
@@ -730,7 +766,7 @@ class Trajectory(Generic[T_Noise, T_State]):
         """Update trajectory score/ending metadata.
 
         Update the maximum of the score function over the trajectory
-        as well as the bool values for has_converged and has_ended.
+        as well as the bool values for has_converged and has_terminated
         """
         new_score_max = 0.0
         for snap in self._snaps:
@@ -740,10 +776,15 @@ class Trajectory(Generic[T_Noise, T_State]):
             self._has_converged = self._fmodel.check_convergence(
                 self._step, self._t_cur, self._score_max, self._convergedVal
             )
+            if self._has_converged:
+                self._has_terminated = True
+            else:
+                self._has_terminated = self._fmodel.check_termination(
+                    self._step, self._t_cur, -1, -1.0, self._score_max
+                )
         else:
             self._has_converged = False
-        if self._t_cur >= self._t_end or self._has_converged:
-            self._has_ended = True
+            self._has_terminated = False
 
     def set_current_time_and_step(self, time: float, step: int) -> None:
         """Set the current time and step."""
@@ -766,9 +807,9 @@ class Trajectory(Generic[T_Noise, T_State]):
         """Return True for converged trajectory."""
         return self._has_converged
 
-    def has_ended(self) -> bool:
+    def is_terminated(self) -> bool:
         """Return True for terminated trajectory."""
-        return self._has_ended
+        return self._has_terminated
 
     def has_started(self) -> bool:
         """Return True if computation has started."""
@@ -845,7 +886,7 @@ class Trajectory(Generic[T_Noise, T_State]):
             "t_end": self._t_end,
             "t_cur": self._t_cur,
             "dt": self._dt,
-            "ended": bool(self._has_ended),
+            "terminated": bool(self._has_terminated),
             "converged": bool(self._has_converged),
             "score_max": float(self._score_max),
             "length": self.get_length(),
@@ -878,7 +919,7 @@ class Trajectory(Generic[T_Noise, T_State]):
             "t_end": float(mstr["t_end"]),
             "t_cur": float(mstr["t_cur"]),
             "dt": float(mstr["dt"]),
-            "ended": mstr["ended"],
+            "terminated": mstr["terminated"],
             "converged": mstr["converged"],
             "score_max": float(mstr["score_max"]),
             "length": int(mstr["length"]),

--- a/pytams/worker.py
+++ b/pytams/worker.py
@@ -59,7 +59,7 @@ def traj_advance_with_exception(
     finally:
         # Update the SQL database
         if trajdb:
-            if traj.has_ended():
+            if traj.is_terminated():
                 trajdb.mark_trajectory_as_completed(traj.id())
             else:
                 trajdb.release_trajectory(traj.id())
@@ -93,7 +93,7 @@ def pool_worker(
     if timedelta:
         wall_time = timedelta.total_seconds()
 
-    if wall_time > 0.0 and not traj.has_ended():
+    if wall_time > 0.0 and not traj.is_terminated():
         # Try to lock the trajectory in the DB
         trajdb = None
         if trajdb_path:

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -114,12 +114,12 @@ def test_access_ensemble_length():
     assert tdb.is_empty() is False
 
 @pytest.mark.dependency(depends=["genDB"])
-def test_access_ended_count():
+def test_access_terminated_count():
     """Test accessing database trajectory metadata."""
     fmodel = DoubleWellModel
     params_load_db = {"database": {"path": "dwTest.tdb"}}
     tdb = Database(fmodel, params_load_db)
-    assert tdb.count_ended_traj() == 50
+    assert tdb.count_terminated_traj() == 50
 
 @pytest.mark.dependency(depends=["genDB"])
 def test_access_converged_count():

--- a/tests/test_trajectory.py
+++ b/tests/test_trajectory.py
@@ -90,7 +90,7 @@ def test_simple_model_traj():
     fmodel = SimpleFModel
     parameters = {"trajectory": {"end_time": 0.04, "step_size": 0.001, "targetscore": 0.25}}
     t_test = Trajectory(1, 1.0, fmodel, parameters)
-    t_test.advance(0.01)
+    t_test.advance(t_end=0.01)
     assert isclose(t_test.score_max(), 0.1, abs_tol=1e-9)
     assert t_test.is_converged() is False
     t_test.advance()
@@ -132,12 +132,26 @@ def test_branch_simple_model_traj():
     assert t_branched.get_computed_steps_count() == 150
 
 
+def test_simple_model_traj_end_nstep():
+    """Test trajectory with simple model."""
+    fmodel = SimpleFModel
+    parameters = {"trajectory": {"step_size": 0.001, "targetscore": 0.55}}
+    t_test = Trajectory(1, 1.0, fmodel, parameters)
+    t_test.advance(nstep_end=20)
+    assert isclose(t_test.score_max(), 0.2, abs_tol=1e-9)
+    assert t_test.is_converged() is False
+    assert t_test.is_terminated() is True
+    t_test.advance(t_end=0.03)
+    assert isclose(t_test.score_max(), 0.3, abs_tol=1e-9)
+    assert t_test.is_converged() is False
+
+
 def test_store_and_restore_simple_traj():
     """Test store and restoring trajectory with simple model."""
     fmodel = SimpleFModel
     parameters = {"trajectory": {"end_time": 0.05, "step_size": 0.001, "targetscore": 0.25}}
     t_test = Trajectory(1, 1.0, fmodel, parameters)
-    t_test.advance(0.02)
+    t_test.advance(t_end=0.02)
     assert isclose(t_test.score_max(), 0.2, abs_tol=1e-9)
     assert t_test.is_converged() is False
     chkfile = Path("./test.xml")
@@ -156,7 +170,7 @@ def test_store_and_restore_frozen_simple_traj():
     fmodel = SimpleFModel
     parameters = {"trajectory": {"end_time": 0.05, "step_size": 0.001, "targetscore": 0.25}}
     t_test = Trajectory(1, 1.0, fmodel, parameters)
-    t_test.advance(0.02)
+    t_test.advance(t_end=0.02)
     assert isclose(t_test.score_max(), 0.2, abs_tol=1e-9)
     assert t_test.is_converged() is False
     chkfile = Path("./test.xml")
@@ -177,7 +191,7 @@ def test_restart_simple_traj():
     fmodel = SimpleFModel
     parameters = {"trajectory": {"end_time": 0.04, "step_size": 0.001, "targetscore": 0.25}}
     from_traj = Trajectory(1, 0.5, fmodel, parameters)
-    from_traj.advance(0.01)
+    from_traj.advance(t_end=0.01)
     rst_traj = Trajectory(2, 0.5, fmodel, parameters)
     rst_test = Trajectory.branch_from_trajectory(from_traj, rst_traj, 0.05, 0.25)
     assert rst_test.current_time() == 0.006
@@ -188,7 +202,7 @@ def test_access_data_simple_traj():
     fmodel = SimpleFModel
     parameters = {"trajectory": {"end_time": 0.04, "step_size": 0.001, "targetscore": 0.25}}
     t_test = Trajectory(1, 1.0, fmodel, parameters)
-    t_test.advance(0.01)
+    t_test.advance(t_end=0.01)
     assert t_test.get_length() == 11
     assert isclose(t_test.get_time_array()[-1], 0.01, abs_tol=1e-9)
     assert isclose(t_test.get_score_array()[-1], 0.1, abs_tol=1e-9)
@@ -199,7 +213,7 @@ def test_sparse_simple_traj():
     fmodel = SimpleFModel
     parameters = {"trajectory": {"end_time": 0.04, "step_size": 0.001, "targetscore": 0.25, "sparse_freq": 5}}
     t_test = Trajectory(1, 1.0, fmodel, parameters)
-    t_test.advance(0.012)
+    t_test.advance(t_end=0.012)
     assert isclose(t_test.score_max(), 0.12, abs_tol=1e-9)
     assert t_test.is_converged() is False
     assert isclose(t_test.get_last_state(), 0.009, abs_tol=1e-9)
@@ -222,7 +236,7 @@ def test_store_and_restart_sparse_simple_traj():
     fmodel = SimpleFModel
     parameters = {"trajectory": {"end_time": 0.04, "step_size": 0.001, "targetscore": 0.25, "sparse_freq": 5}}
     t_test = Trajectory(1, 1.0, fmodel, parameters)
-    t_test.advance(0.013)
+    t_test.advance(t_end=0.013)
     assert isclose(t_test.score_max(), 0.13, abs_tol=1e-9)
     assert t_test.is_converged() is False
     chkfile = Path("./test.xml")
@@ -255,7 +269,7 @@ def test_sparse_dw_traj_with_restore():
         "model": {"noise_amplitude": 0.8},
     }
     t_test = Trajectory(1, 1.0, fmodel, parameters)
-    t_test.advance(4.07)
+    t_test.advance(t_end=4.07)
     chkfile = Path("./test.xml")
     t_test.store(chkfile, write_metadata_json=True)
     assert isclose(t_test.score_max(), 0.5384037112515893, abs_tol=1e-9)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -36,7 +36,7 @@ def test_run_pool_worker_with_sql():
     enddate = datetime.datetime.now(tz=datetime.timezone.utc) + datetime.timedelta(seconds=10.0)
     _ = pool_worker(t_test, enddate, "./test.db")
     _, metadata = poolfile.fetch_trajectory(0)
-    assert metadata["ended"]
+    assert metadata["terminated"]
     del poolfile
     Path("./test.db").unlink()
 
@@ -98,7 +98,7 @@ def test_run_ms_worker_with_sql():
     poolfile.add_trajectory("dummy.xml", rst_test.get_metadata())
     _ = ms_worker(t_test, rst_test, 0.049, 1.0, enddate, "./test.db")
     _, metadata = poolfile.fetch_trajectory(1)
-    assert metadata["ended"]
+    assert metadata["terminated"]
     del poolfile
     Path("./test.db").unlink()
 


### PR DESCRIPTION
Prior to this PR, Trajectories required an end time (in the input TOML file).
This PR allows for open-ended trajectories and encapsulates the Trajectory termination logic in one of the forward model function. The default implementation remains consistent with TAMS, i.e. if an end time is provided in the input file or in the call to the advance() function, the simulation will end when reaching the (minimum) end time. But this function can be updated to terminate based on other considerations (number of steps taken, model state entering phase space region, ...). This opens the door for other sampling algorithm.

The semantics of the Trajectory object was updated: a trajectory can be 'ongoing', 'converged' or 'terminated'. The last state replace the previous 'ended' state to reflect that it might not be related to a end time condition.