### PR TITLE
Reset discarded levels control

### DIFF
--- a/docs/Tutorials.rst
+++ b/docs/Tutorials.rst
@@ -329,7 +329,7 @@ to the algorithm parameters. We will start with a Monte-Carlo sampling approach.
 
     [runner]
     type = "asyncio"
-    nworkers_init=1
+    nworkers=1
 
 With above input parameters, the Monte-Carlo ensemble will contain 200 members.
 The model is assumed to have
@@ -658,8 +658,7 @@ All of these parameter can be set in the ``input.toml`` file (differs from defau
 
     [runner]
     type = "asyncio"
-    nworkers_init=1
-    nworkers_iter=1
+    nworkers=1
 
 Note that the log level here was decreased to ``WARNING`` in order to minimize standard output clutering
 when running TAMS multiple times. Let's now look at the short script provided for running TAMS with the
@@ -1237,8 +1236,7 @@ in order to limit the compute time.
 
     [runner]
     type = "dask"
-    nworkers_init=2
-    nworkers_iter=2
+    nworkers=2
 
 When running the model locally, both `asyncio` and `dask` runner are valid options. Here we use Dask by default,
 spawning two workers during the initial ensemble generation and two workers during the TAMS iterations. The

--- a/docs/Usage.rst
+++ b/docs/Usage.rst
@@ -86,6 +86,7 @@ data structures of the code:
     variant = "tams"            # [OPT, DEF = "tams"] Sampling variant
     end_time = 10.0             # [OPT, DEF = -1] End time, REQ if variant = "tams"
     min_score = 0.01            # [OPT, DEF = None] Minimum score, REQ if variant = "ams"
+    l_j = 2                     # [OPT, DEF = 1] Number of score function levels discarded at each iteration
 
 
     [montecarlo]
@@ -96,7 +97,7 @@ data structures of the code:
   Whem running TAMS, one must specify the number of members in the ensemble :math:`N`
   (``ntrajectories`` in the snippet above) as well as the maximum number of (splitting) iterations :math:`J`
   (``nsplititer`` above). The ``variant`` enable to switch between TAMS and AMS, and a different termination
-  must then be provided.
+  must then be provided. By default, a single score function level is discarded at each iteration (``l_j`` above).
   When running a Monte Carlo run, only the number of ensemble members is required (``ntrajectories`` above).
   If no end time is provided when using Monte-Carlo, trajectory will continue until convergence, which might
   take a long time, so it is recommended to provide an end time if only to avoid infinite trajectories.
@@ -127,18 +128,16 @@ data structures of the code:
   
     [runner]
     type = "asyncio"            # [REQ] Runner type
-    nworkers_init = 2            # [OPT, DEF = 1] Number of workers for initial ensemble generation
-    nworkers_iter = 2            # [OPT, DEF = 1] Number of workers for splitting iterations
+    nworkers = 2                # [OPT, DEF = 1] Number of workers
 
   The ``runner`` manages scheduling the worker tasks over the course of the algorithm. Currently, two
   runner types are supported: ``asyncio`` is a light runner based on `the asyncio library <https://docs.python.org/3/library/asyncio.html>`_
   more suited when running `pyREVS` locally (or within the scope of a Slurm job), and ``dask``
   leverage `Dask <https://www.dask.org/>`_ and is required when deploying a large `pyREVS` run on a
   cluster.
-  [TODO] The ``nworkers_init`` and ``nworkers_iter`` set the number of workers, i.e. number of parallel 
-  tasks, used during the generation of the initial ensemble and during the splitting iterations, respectively.
-  Note that ``nworkers_iter`` effectively set the number of trajectories discarded at each iteration
-  :math:`l_j` (see :ref:`the theory Section <sec:theory>`).
+  The number of independent workers is set by the ``nworkers`` parameter, which defaults to 1. Not that this
+  is a maximum numbers of workers, for instance when running TAMS iteration with a single discarded level, the actual
+  number of workers might be lower (i.e. the ``l_j`` parameter).
 
 - Database parameters:
 

--- a/examples/BiChannel2D/input.toml
+++ b/examples/BiChannel2D/input.toml
@@ -20,8 +20,7 @@ inv_temperature = 3.67
 
 [runner]
 type = "asyncio"
-nworker_init=8
-nworker_iter=1
+nworkers=8
 
 [test]
 trigger_type = "score"

--- a/examples/Boussinesq/input.toml
+++ b/examples/Boussinesq/input.toml
@@ -3,6 +3,7 @@ ntrajectories = 20
 nsplititer = 1000
 variant = "tams"
 end_time = 20.0
+l_j = 2
 
 [sampler]
 strategy = "ams"
@@ -29,8 +30,7 @@ step_size = 0.01
 
 [runner]
 type = "asyncio"
-nworkers_init=2
-nworkers_iter=2
+nworkers=2
 
 [database]
 path = "2DBoussinesq.tdb"

--- a/examples/Boussinesq/input_baars.toml
+++ b/examples/Boussinesq/input_baars.toml
@@ -3,6 +3,7 @@ ntrajectories = 20
 nsplititer = 1000
 variant = "tams"
 end_time = 20.0
+l_j = 2
 
 [sampler]
 strategy = "ams"
@@ -33,8 +34,7 @@ step_size = 0.01
 
 [runner]
 type = "asyncio"
-nworkers_init=2
-nworkers_iter=2
+nworkers=2
 
 [database]
 path = "2DBoussinesq_Baars.tdb"

--- a/examples/Boussinesq/input_podtest.toml
+++ b/examples/Boussinesq/input_podtest.toml
@@ -3,6 +3,7 @@ ntrajectories = 20
 nsplititer = 1000
 variant = "tams"
 end_time = 20.0
+l_j = 2
 
 [sampler]
 strategy = "ams"
@@ -31,8 +32,7 @@ step_size = 0.01
 
 [runner]
 type = "asyncio"
-nworkers_init=2
-nworkers_iter=2
+nworkers=2
 
 [database]
 path = "2DBoussinesq_POD.tdb"

--- a/examples/BoussinesqCpp/input.toml
+++ b/examples/BoussinesqCpp/input.toml
@@ -6,6 +6,7 @@ ntrajectories = 20
 nsplititer = 200
 variant = "tams"
 end_time = 20.0
+l_j = 2
 
 [runtime]
 loglevel = "INFO"
@@ -26,8 +27,7 @@ K = 7
 
 [runner]
 type = "dask"
-nworkers_init=2
-nworkers_iter=2
+nworkers=2
 
 [database]
 path = "2DBoussinesqCpp.tdb"

--- a/examples/DoubleWell2D/input.toml
+++ b/examples/DoubleWell2D/input.toml
@@ -19,5 +19,4 @@ epsilon = 0.2
 
 [runner]
 type = "asyncio"
-nworker_init=2
-nworker_iter=1
+nworkers=2

--- a/examples/DoubleWell2D/input_disk.toml
+++ b/examples/DoubleWell2D/input_disk.toml
@@ -19,8 +19,7 @@ epsilon = 0.2
 
 [runner]
 type = "asyncio"
-nworker_init=2
-nworker_iter=1
+nworkers = 2
 
 [database]
 path = "./dw2dim.tdb"

--- a/examples/DoubleWell2D/input_mc.toml
+++ b/examples/DoubleWell2D/input_mc.toml
@@ -17,4 +17,4 @@ epsilon = 0.2
 
 [runner]
 type = "asyncio"
-nworker_init=2
+nworkers=2

--- a/pyrevs/runner/config.py
+++ b/pyrevs/runner/config.py
@@ -73,16 +73,10 @@ class RunnerConfig:
             "doc": "The type of runner to use. Currently only `asyncio` and `dask` are supported.",
         },
     )
-    nworkers_init: int = field(
+    nworkers: int = field(
         default=1,
         metadata={
-            "doc": "The number of workers used to initialize the ensemeble.",
-        },
-    )
-    nworkers_iter: int = field(
-        default=1,
-        metadata={
-            "doc": "The number of workers used to iterate on the ensemeble.",
+            "doc": "The number of workers.",
         },
     )
     dask_config: DaskConfig = field(

--- a/pyrevs/runner/taskrunner.py
+++ b/pyrevs/runner/taskrunner.py
@@ -350,18 +350,18 @@ class DaskRunner(BaseRunner):
 def make_runner(
     runner_cfg: RunnerConfig,
     worker_fn: Callable,
-    is_pool_worker: bool = False,
     loglevel: str = "INFO",
     logfile: str | None = None,
+    max_workers: int = -1,
 ) -> BaseRunner:
     """Factory that instantiates a configured runner.
 
     Args:
         runner_cfg: a config mapping for the runner
         worker_fn: a worker function
-        is_pool_worker: True if the worker is a pool worker
         loglevel: logging level
         logfile: logging file
+        max_workers: maximum number of workers
     """
     runner_type = runner_cfg.type.lower()
 
@@ -370,7 +370,7 @@ def make_runner(
         "dask": DaskRunner,
     }
 
-    n_workers = runner_cfg.nworkers_init if is_pool_worker else runner_cfg.nworkers_iter
+    n_workers = min(runner_cfg.nworkers, max_workers) if max_workers > 0 else runner_cfg.nworkers
 
     if runner_type not in runner_map:
         err_msg = f"Unknown runner type: {runner_type}"

--- a/pyrevs/strategies/ams/ams.py
+++ b/pyrevs/strategies/ams/ams.py
@@ -137,9 +137,9 @@ class AMS(BaseSamplingStrategy):
         with make_runner(
             self._runner_cfg,
             pool_worker,
-            is_pool_worker=True,
             loglevel=self._loglevel,
             logfile=self._logfile,
+            max_workers=self._ams_cfg.ntrajectories,
         ) as runner:
             for t in tdb.traj_list():
                 task = [t, self._term_crit, self._end_date, tdb.pool_file(), tdb.path()]
@@ -219,9 +219,9 @@ class AMS(BaseSamplingStrategy):
             with make_runner(
                 self._runner_cfg,
                 pool_worker,
-                is_pool_worker=False,
                 loglevel=self._loglevel,
                 logfile=self._logfile,
+                max_workers=self._ams_cfg.l_j,
             ) as runner:
                 for i in ongoing_list:
                     t = tdb.get_traj(i)
@@ -305,9 +305,9 @@ class AMS(BaseSamplingStrategy):
         with make_runner(
             self._runner_cfg,
             ms_worker,
-            is_pool_worker=False,
             loglevel=self._loglevel,
             logfile=self._logfile,
+            max_workers=self._ams_cfg.l_j,
         ) as runner:
             while k < self._ams_cfg.nsplititer:
                 inf_msg = f"Starting AMS iter. {k} with {runner.n_workers()} workers"

--- a/pyrevs/strategies/ams/config.py
+++ b/pyrevs/strategies/ams/config.py
@@ -28,6 +28,12 @@ class AMSConfig:
             "doc": "Variant of AMS to use (one of [tams, ams])",
         },
     )
+    l_j: int = field(
+        default=1,
+        metadata={
+            "doc": "Number of score function levels discarded at each splitting iteration",
+        },
+    )
     init_ensemble_only: bool = field(
         default=False,
         metadata={

--- a/pyrevs/strategies/montecarlo/montecarlo.py
+++ b/pyrevs/strategies/montecarlo/montecarlo.py
@@ -91,9 +91,9 @@ class MonteCarlo(BaseSamplingStrategy):
         with make_runner(
             self._runner_cfg,
             pool_worker,
-            is_pool_worker=True,
             loglevel=self._loglevel,
             logfile=self._logfile,
+            max_workers=self._mc_cfg.ntrajectories,
         ) as runner:
             for t in tdb.traj_list():
                 task = [t, self._term_crit, self._end_date, tdb.pool_file(), tdb.path()]

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -41,7 +41,7 @@ def test_sampling_run():
         "sampler": {"strategy": "ams", "deterministic": True},
         "runtime": {"walltime": 20.0},
         "ams": {"ntrajectories": 20, "nsplititer": 20, "variant": "tams", "end_time": 6.0},
-        "runner": {"type": "asyncio", "nworker_init": 1, "nworker_iter": 1},
+        "runner": {"type": "asyncio", "nworkers": 1},
         "trajectory": {"step_size": 0.01, "targetscore": 0.6},
         "model": {"slow_factor": 0.00000001, "noise_amplitude": 0.6},
     }

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -97,9 +97,9 @@ def test_generate_and_load_tdb():
             {
                 "sampler": {"strategy": "ams"},
                 "runtime": {"loglevel": "INFO"},
-                "ams": {"ntrajectories": 50, "nsplititer": 200, "variant": "tams", "end_time": 10.0},
+                "ams": {"ntrajectories": 50, "nsplititer": 200, "variant": "tams", "end_time": 10.0, "l_j": 1},
                 "database": {"path": "dwTest.tdb"},
-                "runner": {"type": "asyncio", "nworkers_init": 2, "nworkers_iter": 1},
+                "runner": {"type": "asyncio", "nworkers": 2},
                 "model": {"noise_amplitude": 0.8},
                 "trajectory": {"step_size": 0.01, "targetscore": 0.51},
             },

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -422,8 +422,8 @@ def test_doublewell_2_workers_tams():
             {
                 "sampler": {"strategy": "ams", "deterministic": True},
                 "runtime": {"walltime": 500.0},
-                "ams": {"ntrajectories": 50, "nsplititer": 400, "variant": "tams", "end_time": 5.0},
-                "runner": {"type": "dask", "nworkers_init": 2, "nworkers_iter": 2},
+                "ams": {"ntrajectories": 50, "nsplititer": 400, "variant": "tams", "end_time": 5.0, "l_j": 2},
+                "runner": {"type": "dask", "nworkers": 2},
                 "model": {"noise_amplitude": 0.8},
                 "database": {"path": "dwTest.tdb", "archive_discarded": True},
                 "trajectory": {"step_size": 0.01, "targetscore": 0.5},
@@ -457,8 +457,8 @@ def test_doublewell_2_workers_restore_sampler():
             {
                 "sampler": {"strategy": "ams", "deterministic": True},
                 "runtime": {"walltime": 500.0},
-                "ams": {"ntrajectories": 50, "nsplititer": 400, "variant": "tams", "end_time": 5.0},
-                "runner": {"type": "dask", "nworkers_init": 2, "nworkers_iter": 2},
+                "ams": {"ntrajectories": 50, "nsplititer": 400, "variant": "tams", "end_time": 5.0, "l_j": 2},
+                "runner": {"type": "dask", "nworkers": 2},
                 "model": {"noise_amplitude": 0.8},
                 "database": {"path": "dwTest.tdb", "archive_discarded": True},
                 "trajectory": {"step_size": 0.01, "targetscore": 0.5},
@@ -587,7 +587,7 @@ def test_doublewell_slow_tams_restore_more_split():
         "runtime": {"walltime": 20.0},
         "ams": {"ntrajectories": 20, "nsplititer": 20, "variant": "tams", "end_time": 6.0},
         "database": {"path": "dwTest.tdb"},
-        "runner": {"type": "asyncio", "nworkers_init": 2, "nworkers_iter": 1},
+        "runner": {"type": "asyncio", "nworkers": 2},
         "trajectory": {"step_size": 0.01, "targetscore": 0.6},
         "model": {"slow_factor": 0.00000001, "noise_amplitude": 0.6},
     }


### PR DESCRIPTION
When running AMS or TAMS, the number of discarded level at each iterations was controlled by the `runner.nworkers_iter` parameters.
The parameters has been moved to the ams.l_j parameter (defaulting to 1) and the runner initialization process now takes the minimum between `ams.l_j` and `runner.nworkers` to set the number of workers.