### PR TITLE
Runtime fixes

### DIFF
--- a/pyrevs/core/fmodel.py
+++ b/pyrevs/core/fmodel.py
@@ -194,19 +194,21 @@ class ForwardModelBaseClass(ABC, Generic[T_Noise, T_State]):
         """
 
     @final
-    def post_trajectory_branching_hook(self, step: int, time: float) -> None:
+    def post_trajectory_branching_hook(self, step: int, time: float, ancestor_workdir: str) -> None:
         """Model post trajectory branching hook.
 
         Args:
             step: the current step counter
             time: the time of the simulation
+            ancestor_workdir: the ancestor trajectory workdir
         """
         self._step = step
         self._time = time
-        self._trajectory_branching_hook()
+        self._trajectory_branching_hook(ancestor_workdir)
 
-    def _trajectory_branching_hook(self) -> None:
+    def _trajectory_branching_hook(self, ancestor_workdir: str) -> None:
         """Model-specific post trajectory branching hook."""
+        _ = ancestor_workdir
 
     @final
     def post_trajectory_restore_hook(self, step: int, time: float) -> None:

--- a/pyrevs/core/sqlmanager.py
+++ b/pyrevs/core/sqlmanager.py
@@ -36,10 +36,10 @@ class BaseSQLManager:
         # URI mode requires absolute path
         file_path = Path(file_name).absolute().as_posix()
         if in_memory:
-            self._engine = create_engine("sqlite:///:memory:", echo=False)
+            self._engine = create_engine("sqlite:///:memory:", echo=False, connect_args={"timeout": 10.0})
         else:
             uri = f"sqlite:///file:{file_path}?mode=ro&uri=true" if ro_mode else f"sqlite:///{file_path}"
-            self._engine = create_engine(uri, echo=False)
+            self._engine = create_engine(uri, echo=False, connect_args={"timeout": 10.0})
 
         self._Session = sessionmaker(bind=self._engine, expire_on_commit=False)
         self._init_db(base_metadata)

--- a/pyrevs/runner/worker.py
+++ b/pyrevs/runner/worker.py
@@ -11,6 +11,7 @@ from typing import Any
 from pyrevs.core import CoreDB
 from pyrevs.trajectory import Trajectory
 from pyrevs.trajectory.trajectory import WallTimeLimitError
+from pyrevs.trajectory.trajectory import UserInterrupt
 
 if TYPE_CHECKING:
     import concurrent.futures
@@ -57,6 +58,10 @@ def traj_advance_with_exception(
     """
     try:
         traj.advance(walltime=walltime, termination_criteria=termination_criteria)
+
+    except UserInterrupt:
+        warn_msg = f"Trajectory {traj.idstr()} advance ran interrupted with file !"
+        _logger.warning(warn_msg)
 
     except WallTimeLimitError:
         warn_msg = f"Trajectory {traj.idstr()} advance ran out of time !"

--- a/pyrevs/runner/worker.py
+++ b/pyrevs/runner/worker.py
@@ -10,8 +10,8 @@ from typing import TYPE_CHECKING
 from typing import Any
 from pyrevs.core import CoreDB
 from pyrevs.trajectory import Trajectory
+from pyrevs.trajectory.trajectory import UserInterruptError
 from pyrevs.trajectory.trajectory import WallTimeLimitError
-from pyrevs.trajectory.trajectory import UserInterrupt
 
 if TYPE_CHECKING:
     import concurrent.futures
@@ -59,7 +59,7 @@ def traj_advance_with_exception(
     try:
         traj.advance(walltime=walltime, termination_criteria=termination_criteria)
 
-    except UserInterrupt:
+    except UserInterruptError:
         warn_msg = f"Trajectory {traj.idstr()} advance ran interrupted with file !"
         _logger.warning(warn_msg)
 

--- a/pyrevs/strategies/ams/ams.py
+++ b/pyrevs/strategies/ams/ams.py
@@ -15,6 +15,7 @@ from pyrevs.runner import ms_worker
 from pyrevs.runner import pool_worker
 from pyrevs.strategies.base import BaseSamplingStrategy
 from pyrevs.strategies.base import LowScoreTerminationCriterion
+from pyrevs.strategies.base import ModelTerminationCriterion
 from pyrevs.strategies.base import TerminationCriterion
 from pyrevs.strategies.base import TimeTerminationCriterion
 from pyrevs.utils.utils import get_min_scored
@@ -107,6 +108,10 @@ class AMS(BaseSamplingStrategy):
             err_msg = f"Unknown variant {self._ams_cfg.variant}"
             _logger.exception(err_msg)
             raise ValueError(err_msg)
+
+        # If requested, also add the custom model termination check
+        if strategy_cfg.use_custom_termination:
+            self._term_crit.append(ModelTerminationCriterion())
 
     def _req_db_ext(self) -> AMSDatabaseExtension:
         if self._db_ext is None:

--- a/pyrevs/strategies/ams/config.py
+++ b/pyrevs/strategies/ams/config.py
@@ -52,6 +52,12 @@ class AMSConfig:
             "doc": "The minimum score of the trajectory (AMS)",
         },
     )
+    use_custom_termination: bool = field(
+        default=False,
+        metadata={
+            "doc": "Trigger use of the fmodel check_termination during sampling",
+        },
+    )
 
     def validate(self) -> None:
         """Validate AMS configuration."""

--- a/pyrevs/strategies/base/__init__.py
+++ b/pyrevs/strategies/base/__init__.py
@@ -4,4 +4,10 @@ from .termination import ModelTerminationCriterion
 from .termination import TerminationCriterion
 from .termination import TimeTerminationCriterion
 
-__all__ = ["BaseSamplingStrategy", "LowScoreTerminationCriterion", "ModelTerminationCriterion", "TerminationCriterion", "TimeTerminationCriterion"]
+__all__ = [
+    "BaseSamplingStrategy",
+    "LowScoreTerminationCriterion",
+    "ModelTerminationCriterion",
+    "TerminationCriterion",
+    "TimeTerminationCriterion",
+]

--- a/pyrevs/strategies/base/__init__.py
+++ b/pyrevs/strategies/base/__init__.py
@@ -1,6 +1,7 @@
 from .strategy import BaseSamplingStrategy
 from .termination import LowScoreTerminationCriterion
+from .termination import ModelTerminationCriterion
 from .termination import TerminationCriterion
 from .termination import TimeTerminationCriterion
 
-__all__ = ["BaseSamplingStrategy", "LowScoreTerminationCriterion", "TerminationCriterion", "TimeTerminationCriterion"]
+__all__ = ["BaseSamplingStrategy", "LowScoreTerminationCriterion", "ModelTerminationCriterion", "TerminationCriterion", "TimeTerminationCriterion"]

--- a/pyrevs/trajectory/trajectory.py
+++ b/pyrevs/trajectory/trajectory.py
@@ -39,6 +39,8 @@ T_State = TypeVar("T_State")
 class WallTimeLimitError(Exception):
     """Exception for running into wall time limit."""
 
+class UserInterrupt(Exception):
+    """Exception for handling user-triggered interruption."""
 
 def form_trajectory_id(n: int, nb: int = 0) -> str:
     """Helper to assemble a trajectory ID string.
@@ -255,6 +257,7 @@ class Trajectory(Generic[T_Noise, T_State]):
         the end time is reached or the model has converged.
 
         If the walltime limit is reached, a WallTimeLimitError exception is raised.
+        If a 'pyrevs_stop' file is found, a UserInterrupt exception is raised.
         Note that this exception is treated as a warning not an error by the
         pyREVS workers.
 
@@ -269,6 +272,7 @@ class Trajectory(Generic[T_Noise, T_State]):
 
         Raises:
             WallTimeLimitError: if the walltime limit is reached
+            UserInterrupt: if a 'pyrevs_stop' file is found
             RuntimeError: if the model advance run into a problem
         """
         # Check if the trajectory is frozen
@@ -309,6 +313,10 @@ class Trajectory(Generic[T_Noise, T_State]):
             if (time.monotonic() - start_time) >= walltime:
                 break
 
+            # Check for user interruption
+            if self.interrupt_trigger():
+                break
+
         # If the model has converged, terminate
         if self._has_converged:
             self._has_terminated = True
@@ -323,10 +331,23 @@ class Trajectory(Generic[T_Noise, T_State]):
             self._diagplugins = []
             self._initialized_diags = False
 
+        if self.interrupt_trigger():
+            warn_msg = f"{self.idstr()} interrupt during advance()"
+            _logger.warning(warn_msg)
+            raise UserInterrupt(warn_msg)
+
         if (time.monotonic() - start_time) >= walltime:
             warn_msg = f"{self.idstr()} ran out of time in advance()"
             _logger.warning(warn_msg)
             raise WallTimeLimitError(warn_msg)
+
+    def interrupt_trigger(self) -> bool:
+        """Check for user interrupt trigger.
+
+        pyREVS can be interrupted cleanly by creating a
+        pyrevs_stop file in the run folder.
+        """
+        return Path("./pyrevs_stop").exists()
 
     def _runtime_termination(self, end_time: float, nstep_end: int) -> bool:
         """Returns True if the trajectory should terminate from the runtime arguments."""

--- a/pyrevs/trajectory/trajectory.py
+++ b/pyrevs/trajectory/trajectory.py
@@ -8,6 +8,7 @@ import shutil
 import time
 import xml.etree.ElementTree as ET
 from dataclasses import asdict
+from math import isclose
 from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Any
@@ -352,7 +353,8 @@ class Trajectory(Generic[T_Noise, T_State]):
     def _runtime_termination(self, end_time: float, nstep_end: int) -> bool:
         """Returns True if the trajectory should terminate from the runtime arguments."""
         step_termination = self._step >= nstep_end if nstep_end > 0 else False
-        time_termination = self._t_cur >= end_time if end_time > 0.0 else False
+        time_termination = (isclose(self._t_cur, end_time, abs_tol=1e-9) or
+                            self._t_cur >= end_time) if end_time > 0.0 else False
         return step_termination or time_termination
 
     def _calculate_end_time(self, t_end: float) -> float:
@@ -575,10 +577,11 @@ class Trajectory(Generic[T_Noise, T_State]):
                     rest_traj.noise_backlog.append(rest_traj._snaps[k].noise)
                     rest_traj._snaps.pop()
                 else:
-                    # Because the noise in the snapshot is the noise
-                    # used to reach the next state, append the last to the backlog too
-                    rest_traj.noise_backlog.append(rest_traj._snaps[k].noise)
                     break
+
+            # Because the noise in the snapshot is the noise
+            # used to reach the next state, append the last to the backlog too
+            rest_traj.noise_backlog.append(rest_traj._snaps[-1].noise)
 
             # Current step with python indexing, so remove 1
             rest_traj.set_current_time_and_step(rest_traj._snaps[-1].time, len(rest_traj._snaps) - 1)
@@ -632,7 +635,8 @@ class Trajectory(Generic[T_Noise, T_State]):
         cls._transfer_data(from_traj, rest_traj, high_score_idx, last_snap_with_state)
 
         # Finalize branching
-        cls._finalize_branch(from_traj.unique_id(), rst_traj.unique_id(), rest_traj, new_weight)
+        ancestor_workdir = from_traj.get_workdir()
+        cls._finalize_branch(from_traj.unique_id(), rst_traj.unique_id(), rest_traj, new_weight, ancestor_workdir)
 
         return rest_traj
 
@@ -712,13 +716,19 @@ class Trajectory(Generic[T_Noise, T_State]):
         """
         # Prepend existing backlog if states align
         if state_idx == from_traj.get_last_state_id() and from_traj.noise_backlog:
+
+            # Grab the noise that might already has been moved from the backlog
+            # to the current noise increment
+            if from_traj._fmodel and from_traj._fmodel.noise is not None:
+                 rest_traj.noise_backlog.append(from_traj._fmodel.noise)
+
             rest_traj.noise_backlog.extend(reversed(from_traj.noise_backlog))
 
         # Separate snapshots from noise backlog
         # Everything up to the last state is a full snapshot
         rest_traj._snaps = from_traj._snaps[: state_idx + 1]
 
-        # Everything between last state and high_score_idx becomes noise backlog
+        # Everything from last state and high_score_idx becomes noise backlog
         for k in range(state_idx, high_idx + 1):
             rest_traj.noise_backlog.append(from_traj._snaps[k].noise)
 
@@ -726,7 +736,8 @@ class Trajectory(Generic[T_Noise, T_State]):
 
     @staticmethod
     def _finalize_branch(
-        ancestor_id: int, discarded_id: int, rest_traj: Trajectory[T_Noise, T_State], weight: float
+        ancestor_id: int, discarded_id: int, rest_traj: Trajectory[T_Noise, T_State], weight: float,
+        ancestor_workdir: Path,
     ) -> None:
         """Finalizes metadata, model state, and diagnostics.
 
@@ -735,6 +746,7 @@ class Trajectory(Generic[T_Noise, T_State]):
             discarded_id: the unique ID of the discarded traj
             rest_traj: the child trajectory
             weight: the weight of the new child trajectory
+            ancestor_workdir: the workdir of the ancestor trajectory
         """
         rest_traj._t_cur = rest_traj._snaps[-1].time
         rest_traj._step = len(rest_traj._snaps) - 1
@@ -746,7 +758,7 @@ class Trajectory(Generic[T_Noise, T_State]):
                 rest_traj._fmodel.set_current_state(last_snap.state)
 
             rest_traj.update_metadata()
-            rest_traj._fmodel.post_trajectory_branching_hook(rest_traj._step, rest_traj._t_cur)
+            rest_traj._fmodel.post_trajectory_branching_hook(rest_traj._step, rest_traj._t_cur, ancestor_workdir.absolute().as_posix())
 
         if rest_traj._has_diagnostics:
             rest_traj._branch_diagnostics(

--- a/pyrevs/trajectory/trajectory.py
+++ b/pyrevs/trajectory/trajectory.py
@@ -40,8 +40,10 @@ T_State = TypeVar("T_State")
 class WallTimeLimitError(Exception):
     """Exception for running into wall time limit."""
 
-class UserInterrupt(Exception):
+
+class UserInterruptError(Exception):
     """Exception for handling user-triggered interruption."""
+
 
 def form_trajectory_id(n: int, nb: int = 0) -> str:
     """Helper to assemble a trajectory ID string.
@@ -258,7 +260,7 @@ class Trajectory(Generic[T_Noise, T_State]):
         the end time is reached or the model has converged.
 
         If the walltime limit is reached, a WallTimeLimitError exception is raised.
-        If a 'pyrevs_stop' file is found, a UserInterrupt exception is raised.
+        If a 'pyrevs_stop' file is found, a UserInterruptError exception is raised.
         Note that this exception is treated as a warning not an error by the
         pyREVS workers.
 
@@ -273,7 +275,7 @@ class Trajectory(Generic[T_Noise, T_State]):
 
         Raises:
             WallTimeLimitError: if the walltime limit is reached
-            UserInterrupt: if a 'pyrevs_stop' file is found
+            UserInterruptError: if a 'pyrevs_stop' file is found
             RuntimeError: if the model advance run into a problem
         """
         # Check if the trajectory is frozen
@@ -318,11 +320,28 @@ class Trajectory(Generic[T_Noise, T_State]):
             if self.interrupt_trigger():
                 break
 
+        # Wrap-up the advance function
+        self._terminate_advance(start_time, walltime)
+
+    def _terminate_advance(self, start_time: float, walltime: float) -> None:
+        """Wrap-up the advance function.
+
+        Args:
+            start_time: the start time of the advance
+            walltime: the walltime limit
+
+        Returns:
+            None
+
+        Raises:
+            WallTimeLimitError: if the walltime limit is reached
+            UserInterruptError: if a 'pyrevs_stop' file is found
+        """
         # If the model has converged, terminate
         if self._has_converged:
             self._has_terminated = True
 
-        if self._has_terminated:
+        if self._has_terminated and self._fmodel:
             self._fmodel.clear()
 
         # Clear the diagnostic
@@ -335,7 +354,7 @@ class Trajectory(Generic[T_Noise, T_State]):
         if self.interrupt_trigger():
             warn_msg = f"{self.idstr()} interrupt during advance()"
             _logger.warning(warn_msg)
-            raise UserInterrupt(warn_msg)
+            raise UserInterruptError(warn_msg)
 
         if (time.monotonic() - start_time) >= walltime:
             warn_msg = f"{self.idstr()} ran out of time in advance()"
@@ -353,8 +372,9 @@ class Trajectory(Generic[T_Noise, T_State]):
     def _runtime_termination(self, end_time: float, nstep_end: int) -> bool:
         """Returns True if the trajectory should terminate from the runtime arguments."""
         step_termination = self._step >= nstep_end if nstep_end > 0 else False
-        time_termination = (isclose(self._t_cur, end_time, abs_tol=1e-9) or
-                            self._t_cur >= end_time) if end_time > 0.0 else False
+        time_termination = (
+            (isclose(self._t_cur, end_time, abs_tol=1e-9) or self._t_cur >= end_time) if end_time > 0.0 else False
+        )
         return step_termination or time_termination
 
     def _calculate_end_time(self, t_end: float) -> float:
@@ -716,11 +736,10 @@ class Trajectory(Generic[T_Noise, T_State]):
         """
         # Prepend existing backlog if states align
         if state_idx == from_traj.get_last_state_id() and from_traj.noise_backlog:
-
             # Grab the noise that might already has been moved from the backlog
             # to the current noise increment
             if from_traj._fmodel and from_traj._fmodel.noise is not None:
-                 rest_traj.noise_backlog.append(from_traj._fmodel.noise)
+                rest_traj.noise_backlog.append(from_traj._fmodel.noise)
 
             rest_traj.noise_backlog.extend(reversed(from_traj.noise_backlog))
 
@@ -736,7 +755,10 @@ class Trajectory(Generic[T_Noise, T_State]):
 
     @staticmethod
     def _finalize_branch(
-        ancestor_id: int, discarded_id: int, rest_traj: Trajectory[T_Noise, T_State], weight: float,
+        ancestor_id: int,
+        discarded_id: int,
+        rest_traj: Trajectory[T_Noise, T_State],
+        weight: float,
         ancestor_workdir: Path,
     ) -> None:
         """Finalizes metadata, model state, and diagnostics.
@@ -758,7 +780,9 @@ class Trajectory(Generic[T_Noise, T_State]):
                 rest_traj._fmodel.set_current_state(last_snap.state)
 
             rest_traj.update_metadata()
-            rest_traj._fmodel.post_trajectory_branching_hook(rest_traj._step, rest_traj._t_cur, ancestor_workdir.absolute().as_posix())
+            rest_traj._fmodel.post_trajectory_branching_hook(
+                rest_traj._step, rest_traj._t_cur, ancestor_workdir.absolute().as_posix()
+            )
 
         if rest_traj._has_diagnostics:
             rest_traj._branch_diagnostics(

--- a/tests/test_trajectory.py
+++ b/tests/test_trajectory.py
@@ -128,12 +128,12 @@ def test_branch_simple_model_traj():
     cfg = Config({"trajectory": {"end_time": 0.04, "step_size": 0.0002, "targetscore": 0.45}})
     t_ancestor = Trajectory(1, 0.5, fmodel, cfg.load(TrajectoryConfig))
     t_ancestor.advance()
-    assert t_ancestor.get_computed_steps_count() == 201
+    assert t_ancestor.get_computed_steps_count() == 200
     t_branched = Trajectory(2, 0.5, fmodel, cfg.load(TrajectoryConfig))
     t_branched = Trajectory.branch_from_trajectory(t_ancestor, t_branched, 0.1, 0.25)
     assert t_branched.get_computed_steps_count() == 0
     t_branched.advance()
-    assert t_branched.get_computed_steps_count() == 150
+    assert t_branched.get_computed_steps_count() == 149
 
 
 def test_simple_model_traj_end_nstep():


### PR DESCRIPTION
A set of convenience features and small changes found while running TAMS on POP:
 - Add timeout to SQLAlchemy engine to avoid locked database error. It might not be sufficient if we start adding very large datasets to the databases.
 - Add basics for clean interruption of sampling run using a disk file "pyrevs_stop". Note: the file is not deleted in the process so users should manually remove it before restarting.
 - Enable a custom termination condition when running AMS sampling. The termination function is provided in the forward model definition.
 - The post-branching hook can be optionally defined in the forward model so that users can operate on auxiliary model data at the branching point. The working directory of the ancestor simulation is now passed into the hook, facilitating accessing ancestor data.
 - Regularly floating-point comparison led to an extra step being performed at the end of a trajectory. Use math.isclose() with a e-9 absolute error to prevent this behavior.